### PR TITLE
fix: forward render_markup in tooltip path (fixes harlequin#933 JSON crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixes the crash reported in [tconbeer/harlequin#933](https://github.com/tconbeer/harlequin/issues/933) by forward `render_markup` in tooltip path (thank you [@crossi-dev](https://github.com/crossi-dev)!).
+
 ## [0.14.0] - 2025-10-25
 
 - Fixes column rendering bug to make compatible with recent versions of Textual.

--- a/src/textual_fastdatatable/data_table.py
+++ b/src/textual_fastdatatable/data_table.py
@@ -2545,7 +2545,10 @@ class DataTable(ScrollView, can_focus=True):
                     (str, float, Decimal, int, datetime, time, date, timedelta),
                 ):
                     self._tooltip_cache[cache_key] = cell_formatter(
-                        raw_value, null_rep=self.null_rep, col=column
+                        raw_value,
+                        null_rep=self.null_rep,
+                        col=column,
+                        render_markup=self.render_markup,
                     )
                 else:
                     self._tooltip_cache[cache_key] = Pretty(raw_value)

--- a/tests/unit_tests/test_format.py
+++ b/tests/unit_tests/test_format.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from rich.console import Console
+from rich.text import Text
+
+from textual_fastdatatable.format import cell_formatter
+
+
+def _can_render(renderable: object) -> bool:
+    """Return True if Rich can render *renderable* without raising."""
+    console = Console()
+    try:
+        with console.capture():
+            console.print(renderable)
+        return True
+    except Exception:
+        return False
+
+
+def test_cell_formatter_json_null_render_markup_false() -> None:
+    """A JSON string containing [null] must not produce markup spans when render_markup=False.
+
+    Regression test for https://github.com/tconbeer/harlequin/issues/933:
+    hovering a cell whose value is a JSON string with a ``[null]`` array element
+    crashed Harlequin with ``MissingStyle: Failed to get style 'null'`` because
+    the tooltip code path called cell_formatter without forwarding
+    render_markup=self.render_markup.  With render_markup=True (the wrong default),
+    Rich parses ``[null]`` as a markup tag and creates a Span with style ``"null"``,
+    which Textual's style resolver later rejects.
+
+    With render_markup=False the string must be returned as plain escaped text with
+    no spans, so it is always safe to render.
+    """
+    json_str = (
+        '{"color":[null],"b":"testtesttesttesttesttesttesttesttesttesttesttesttest"}'
+    )
+    result = cell_formatter(json_str, null_rep=Text(""), render_markup=False)
+
+    # Must be renderable without errors.
+    assert _can_render(result), (
+        "cell_formatter with render_markup=False produced an unrenderable object "
+        "for a JSON string containing [null]"
+    )
+
+    # Must not contain any span whose style is the bare word "null" — that would
+    # indicate the string was parsed as Rich markup.
+    if isinstance(result, Text):
+        null_spans = [span for span in result._spans if span.style == "null"]
+        assert not null_spans, (
+            f"cell_formatter with render_markup=False must not produce spans with "
+            f"style 'null'; got {null_spans}"
+        )

--- a/tests/unit_tests/test_format.py
+++ b/tests/unit_tests/test_format.py
@@ -18,7 +18,8 @@ def _can_render(renderable: object) -> bool:
 
 
 def test_cell_formatter_json_null_render_markup_false() -> None:
-    """A JSON string containing [null] must not produce markup spans when render_markup=False.
+    """A JSON string containing [null] must not produce markup spans when
+    render_markup=False.
 
     Regression test for https://github.com/tconbeer/harlequin/issues/933:
     hovering a cell whose value is a JSON string with a ``[null]`` array element


### PR DESCRIPTION
Fixes the crash reported in tconbeer/harlequin#933 ("Harlequin crashes on json object"), which originates here.

**Root cause:** `DataTable._set_tooltip_from_cell_at()` calls `cell_formatter(...)` without forwarding `render_markup`, so it defaults to `True` even when the table was created with `render_markup=False` (as Harlequin's `ResultsTable` does). Every other `cell_formatter` call site passes `render_markup=self.render_markup` — the tooltip path was the one exception. With markup on, a JSON value containing `[null]` gets parsed as a Rich markup tag → a span with style `"null"` → `MissingStyle: Failed to get style 'null'` at render time.

**Fix:** forward `render_markup=self.render_markup` in the tooltip path, making it consistent with the rest of the file. One added argument, no behavior change for markup-enabled tables.

**Verified locally:** reproduced the crash before, confirmed gone after; suite green (31 tests here + 67 in harlequin, no regressions) + a new regression test.

---

Came across harlequin (great tool) and traced #933 down to this repo, so I fixed it. No strings — glad if it helps. I do this kind of work (Choreless — we fix and ship code for small teams), so if you ever want a hand, I'm around. — Charles
