### PR TITLE
fix: escape and truncate bytes values in cell formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fixes the crash reported in [tconbeer/harlequin#933](https://github.com/tconbeer/harlequin/issues/933) by forward `render_markup` in tooltip path (thank you [@crossi-dev](https://github.com/crossi-dev)!).
+- Fixes the crash reported in [tconbeer/harlequin#974](https://github.com/tconbeer/harlequin/issues/974) by escaping and truncating bytes values in cell formatter (thank you [@Pawansingh3889](https://github.com/Pawansingh3889)!).
 
 ## [0.14.0] - 2025-10-25
 

--- a/src/textual_fastdatatable/format.py
+++ b/src/textual_fastdatatable/format.py
@@ -89,6 +89,16 @@ def cell_formatter(
     elif isinstance(obj, timedelta):
         return Align(str(obj), align="right")
 
+    elif isinstance(obj, (bytes, bytearray, memoryview)):
+        # binary values (e.g. varbinary columns) can contain sequences like
+        # [/...] that Rich would try to parse as markup; show an escaped,
+        # truncated preview instead. See tconbeer/harlequin#974.
+        data = bytes(obj)
+        preview = repr(data[:32])
+        if len(data) > 32:
+            preview = f"{preview} (+{len(data) - 32} bytes)"
+        return escape(preview)
+
     elif not is_renderable(obj):
         return str(obj)
 

--- a/tests/unit_tests/test_format.py
+++ b/tests/unit_tests/test_format.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from rich.console import Console
 from rich.text import Text
 
-from textual_fastdatatable.format import cell_formatter
+from textual_fastdatatable.format import cell_formatter, measure_width
+
+NULL = Text("")
 
 
 def _can_render(renderable: object) -> bool:
@@ -51,3 +53,41 @@ def test_cell_formatter_json_null_render_markup_false() -> None:
             f"cell_formatter with render_markup=False must not produce spans with "
             f"style 'null'; got {null_spans}"
         )
+
+
+def test_bytes_with_markup_hostile_content_do_not_raise() -> None:
+    # regression test for tconbeer/harlequin#974: varbinary values arrive as
+    # bytes and can contain [/...] sequences that Rich parses as closing tags
+    hostile = b"[/l\x1d\x1a\t#\xd9\xfa9Z\xa9\xe4\x8e\xab\xfaH\x18\xba\x91\xd2"
+    rendered = cell_formatter(hostile, null_rep=NULL)
+    assert isinstance(rendered, str)
+    # must not raise MarkupError
+    Text.from_markup(rendered)
+
+
+def test_bytes_preview_is_truncated() -> None:
+    data = bytes(range(256))
+    rendered = cell_formatter(data, null_rep=NULL)
+    assert isinstance(rendered, str)
+    assert "(+224 bytes)" in rendered
+
+
+def test_short_bytes_not_truncated() -> None:
+    rendered = cell_formatter(b"abc", null_rep=NULL)
+    assert isinstance(rendered, str)
+    assert "bytes)" not in rendered
+    Text.from_markup(rendered)
+
+
+def test_bytearray_and_memoryview() -> None:
+    for value in (bytearray(b"[/x]"), memoryview(b"[/x]")):
+        rendered = cell_formatter(value, null_rep=NULL)
+        assert isinstance(rendered, str)
+        Text.from_markup(rendered)
+
+
+def test_bytes_are_measurable() -> None:
+    from rich.console import Console
+
+    width = measure_width(b"[/l\xd9\xfa9Z", Console())
+    assert width > 0


### PR DESCRIPTION
Fixes the crash reported in tconbeer/harlequin#974, per your go-ahead there.

varbinary columns arrive from the ODBC adapter as Python bytes. `cell_formatter` had no bytes branch, so values fell through to `str(obj)`, and byte sequences like `[/l...]` reached Rich's markup parser as unmatched closing tags, raising `MarkupError`.

This adds a `bytes`/`bytearray`/`memoryview` branch that renders an escaped, truncated preview: `repr` of the first 32 bytes, with a `(+N bytes)` suffix for longer values. Long blobs no longer hit the renderer at full size either; the failing value in the report was over 780 KB.

Tests cover the markup-hostile bytes from the report, truncation, short values, bytearray and memoryview, and width measurement. Unit suite passes 35/35 locally.