### PR TITLE
fix: truncate tooltip content so it cannot cover the mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixes the flickering tooltip reported in
+  [tconbeer/harlequin#894](https://github.com/tconbeer/harlequin/issues/894). Tooltip
+  content is now truncated (with a `… (truncated)` marker) to at most half the height of
+  the screen, so the tooltip can no longer be clamped over the mouse, which caused
+  Textual to clear and re-show it indefinitely.
+
 ## [0.16.0] - 2026-08-05
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixes the flickering tooltip reported in
+  [tconbeer/harlequin#894](https://github.com/tconbeer/harlequin/issues/894). Tooltip
+  content is now truncated (with a `… (truncated)` marker) to at most half the height of
+  the screen, so the tooltip can no longer be clamped over the mouse, which caused
+  Textual to clear and re-show it indefinitely.
+
 ## [0.17.1] - 2026-08-10
 
 - `textual_fastdatatable.backend` can now be imported without importing `rich`, which is

--- a/src/textual_fastdatatable/data_table.py
+++ b/src/textual_fastdatatable/data_table.py
@@ -44,6 +44,7 @@ from textual.binding import Binding, BindingType
 from textual.cache import LRUCache
 from textual.color import Color
 from textual.coordinate import Coordinate
+from textual.dom import NoScreen
 from textual.geometry import Region, Size, Spacing, clamp
 from textual.message import Message
 from textual.reactive import Reactive
@@ -56,13 +57,27 @@ from typing_extensions import Self
 
 from textual_fastdatatable.backend import DataTableBackend, create_backend
 from textual_fastdatatable.column import Column
-from textual_fastdatatable.format import cell_formatter, measure_width
+from textual_fastdatatable.format import (
+    cell_formatter,
+    measure_width,
+    truncate_renderable,
+)
 
 CursorType = Literal["cell", "range", "row", "column", "none"]
 """The valid types of cursors for
 [`DataTable.cursor_type`][textual.widgets.DataTable.cursor_type]."""
 SegmentLines = list[list[Segment]]
-TooltipCacheKey = tuple[int, int, int]
+TooltipCacheKey = tuple[int, int, int, int]
+
+TOOLTIP_CONTENT_WIDTH = 36
+"""The width available to tooltip content: Textual's Tooltip is `max-width: 40`
+with `padding: 1 2`."""
+TOOLTIP_HEIGHT_OVERHEAD = 4
+"""Rows a tooltip occupies in addition to its content: `padding: 1 2` and
+`margin: 1 0`."""
+MIN_TOOLTIP_CONTENT_HEIGHT = 2
+"""Never truncate tooltip content below this many lines (one line of content and
+the truncation marker), no matter how short the terminal is."""
 CellCacheKey = tuple[int, int, Style, bool, bool, bool, bool, int, PseudoClasses]
 LineCacheKey = tuple[
     int,
@@ -2499,9 +2514,34 @@ class DataTable(ScrollView, can_focus=True):
 
         self._set_tooltip_from_cell_at(mouse_coordinate)
 
+    @property
+    def _max_tooltip_lines(self) -> int:
+        """The tallest a tooltip can be without covering the mouse.
+
+        Textual positions the tooltip at the mouse and constrains it to the screen,
+        inflecting it above the mouse if it does not fit below. A tooltip that fits
+        on neither side is clamped to the screen, where it covers the mouse; Textual
+        then clears it, the mouse moves onto the cell again, and the tooltip flickers
+        forever (see tconbeer/harlequin#894). Half the screen always fits on one
+        side of the mouse.
+        """
+        try:
+            screen_height = self.screen.size.height
+        except NoScreen:
+            screen_height = self.size.height
+        return max(
+            MIN_TOOLTIP_CONTENT_HEIGHT, screen_height // 2 - TOOLTIP_HEIGHT_OVERHEAD
+        )
+
     def _set_tooltip_from_cell_at(self, coordinate: Coordinate) -> None:
         # TODO: support row labels
-        cache_key = (coordinate.row, coordinate.column, self._update_count)
+        max_lines = self._max_tooltip_lines
+        cache_key = (
+            coordinate.row,
+            coordinate.column,
+            self._update_count,
+            max_lines,
+        )
         column = self.ordered_columns[coordinate.column]
         if cache_key not in self._tooltip_cache:
             if coordinate.row == -1:  # hover over header
@@ -2515,20 +2555,32 @@ class DataTable(ScrollView, can_focus=True):
                 self.max_column_content_width is not None
                 and measured_width > self.max_column_content_width
             ) or (measured_width > column.render_width):
+                if isinstance(raw_value, str):
+                    # a value that fits in the tooltip can never contain more
+                    # characters than the tooltip has cells; slicing first keeps
+                    # us from formatting and rendering megabytes of JSON that
+                    # would only be discarded below.
+                    raw_value = raw_value[: TOOLTIP_CONTENT_WIDTH * (max_lines + 1)]
                 if isinstance(raw_value, Text):
-                    self._tooltip_cache[cache_key] = raw_value
+                    renderable: RenderableType = raw_value
                 elif isinstance(
                     raw_value,
                     (str, float, Decimal, int, datetime, time, date, timedelta),
                 ):
-                    self._tooltip_cache[cache_key] = cell_formatter(
+                    renderable = cell_formatter(
                         raw_value,
                         null_rep=self.null_rep,
                         col=column,
                         render_markup=self.render_markup,
                     )
                 else:
-                    self._tooltip_cache[cache_key] = Pretty(raw_value)
+                    renderable = Pretty(raw_value)
+                self._tooltip_cache[cache_key] = truncate_renderable(
+                    renderable,
+                    console=self.app.console,
+                    max_width=TOOLTIP_CONTENT_WIDTH,
+                    max_lines=max_lines,
+                )
             else:
                 self._tooltip_cache[cache_key] = None
         self.tooltip = self._tooltip_cache[cache_key]

--- a/src/textual_fastdatatable/data_table.py
+++ b/src/textual_fastdatatable/data_table.py
@@ -44,6 +44,7 @@ from textual.binding import Binding, BindingType
 from textual.cache import LRUCache
 from textual.color import Color
 from textual.coordinate import Coordinate
+from textual.css.query import NoMatches
 from textual.dom import NoScreen
 from textual.geometry import Region, Size, Spacing, clamp
 from textual.message import Message
@@ -53,6 +54,7 @@ from textual.renderables.styled import Styled
 from textual.scroll_view import ScrollView
 from textual.strip import Strip
 from textual.widget import PseudoClasses
+from textual.widgets import Tooltip
 from typing_extensions import Self
 
 from textual_fastdatatable.backend import DataTableBackend, create_backend
@@ -67,14 +69,14 @@ CursorType = Literal["cell", "range", "row", "column", "none"]
 """The valid types of cursors for
 [`DataTable.cursor_type`][textual.widgets.DataTable.cursor_type]."""
 SegmentLines = list[list[Segment]]
-TooltipCacheKey = tuple[int, int, int, int]
+TooltipCacheKey = tuple[int, int, int, int, int]
 
-TOOLTIP_CONTENT_WIDTH = 36
-"""The width available to tooltip content: Textual's Tooltip is `max-width: 40`
-with `padding: 1 2`."""
-TOOLTIP_HEIGHT_OVERHEAD = 4
-"""Rows a tooltip occupies in addition to its content: `padding: 1 2` and
-`margin: 1 0`."""
+# Tooltips are styled by the app, so their size is read from the Tooltip widget
+# (see _tooltip_content_size); these are only fallbacks for when there is none,
+# and match Textual's own Tooltip CSS.
+DEFAULT_TOOLTIP_MAX_WIDTH = 40
+DEFAULT_TOOLTIP_GUTTER = Spacing(1, 2, 1, 2)
+DEFAULT_TOOLTIP_MARGIN = Spacing(1, 0, 1, 0)
 MIN_TOOLTIP_CONTENT_HEIGHT = 2
 """Never truncate tooltip content below this many lines (one line of content and
 the truncation marker), no matter how short the terminal is."""
@@ -2514,32 +2516,63 @@ class DataTable(ScrollView, can_focus=True):
 
         self._set_tooltip_from_cell_at(mouse_coordinate)
 
-    @property
-    def _max_tooltip_lines(self) -> int:
-        """The tallest a tooltip can be without covering the mouse.
+    def _tooltip_content_size(self) -> tuple[int, int]:
+        """The width and height available to tooltip content, in cells.
 
+        The height is the tallest a tooltip can be without covering the mouse.
         Textual positions the tooltip at the mouse and constrains it to the screen,
         inflecting it above the mouse if it does not fit below. A tooltip that fits
         on neither side is clamped to the screen, where it covers the mouse; Textual
         then clears it, the mouse moves onto the cell again, and the tooltip flickers
         forever (see tconbeer/harlequin#894). Half the screen always fits on one
         side of the mouse.
+
+        Both dimensions come from the Tooltip widget's own styles, since an app is
+        free to restyle it.
         """
+        tooltip: Tooltip | None = None
         try:
-            screen_height = self.screen.size.height
+            screen = self.screen
         except NoScreen:
-            screen_height = self.size.height
-        return max(
-            MIN_TOOLTIP_CONTENT_HEIGHT, screen_height // 2 - TOOLTIP_HEIGHT_OVERHEAD
-        )
+            screen_size = self.size
+        else:
+            screen_size = screen.size
+            try:
+                tooltip = screen.get_child_by_type(Tooltip)
+            except NoMatches:
+                pass  # tooltips are disabled; fall back to Textual's own styles
+
+        gutter = DEFAULT_TOOLTIP_GUTTER
+        margin = DEFAULT_TOOLTIP_MARGIN
+        max_width = DEFAULT_TOOLTIP_MAX_WIDTH
+        max_height: int | None = None
+        if tooltip is not None:
+            styles = tooltip.styles
+            gutter = tooltip.gutter  # padding and border
+            margin = styles.margin
+            max_width = (
+                int(styles.max_width.resolve(screen_size, screen_size))
+                if styles.max_width is not None
+                else screen_size.width
+            )
+            if styles.max_height is not None:
+                max_height = int(styles.max_height.resolve(screen_size, screen_size))
+
+        content_width = max(1, min(max_width, screen_size.width) - gutter.width)
+        content_height = screen_size.height // 2 - gutter.height - margin.height
+        if max_height is not None:
+            # respect a shorter tooltip, so the truncation marker isn't clipped
+            content_height = min(content_height, max_height - gutter.height)
+        return content_width, max(MIN_TOOLTIP_CONTENT_HEIGHT, content_height)
 
     def _set_tooltip_from_cell_at(self, coordinate: Coordinate) -> None:
         # TODO: support row labels
-        max_lines = self._max_tooltip_lines
+        max_width, max_lines = self._tooltip_content_size()
         cache_key = (
             coordinate.row,
             coordinate.column,
             self._update_count,
+            max_width,
             max_lines,
         )
         column = self.ordered_columns[coordinate.column]
@@ -2560,7 +2593,7 @@ class DataTable(ScrollView, can_focus=True):
                     # characters than the tooltip has cells; slicing first keeps
                     # us from formatting and rendering megabytes of JSON that
                     # would only be discarded below.
-                    raw_value = raw_value[: TOOLTIP_CONTENT_WIDTH * (max_lines + 1)]
+                    raw_value = raw_value[: max_width * (max_lines + 1)]
                 if isinstance(raw_value, Text):
                     renderable: RenderableType = raw_value
                 elif isinstance(
@@ -2578,7 +2611,7 @@ class DataTable(ScrollView, can_focus=True):
                 self._tooltip_cache[cache_key] = truncate_renderable(
                     renderable,
                     console=self.app.console,
-                    max_width=TOOLTIP_CONTENT_WIDTH,
+                    max_width=max_width,
                     max_lines=max_lines,
                 )
             else:

--- a/src/textual_fastdatatable/format.py
+++ b/src/textual_fastdatatable/format.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
+from itertools import chain
 from typing import cast
 
 from rich.align import Align
@@ -125,18 +126,20 @@ def truncate_renderable(
     if max_lines < 2 or max_width < 1:
         return renderable
     options = console.options.update(width=max_width, height=None, overflow="fold")
-    lines = console.render_lines(renderable, options, pad=False, new_lines=False)
+    # new_lines=True terminates every line, including the last: Textual sizes a
+    # renderable by counting its newlines, and would otherwise clip the marker.
+    lines = console.render_lines(renderable, options, pad=False, new_lines=True)
     if len(lines) <= max_lines:
         return renderable
 
     ellipsis = Text("… (truncated)", style="italic dim", no_wrap=True)
-    segments: list[Segment] = []
-    for line in [*lines[: max_lines - 1], list(ellipsis.render(console))]:
-        segments.extend(line)
-        # every line needs its newline: Textual sizes a renderable by counting
-        # the newlines in it, and would otherwise clip the last line.
-        segments.append(Segment.line())
-    return Segments(segments)
+    return Segments(
+        [
+            *chain.from_iterable(lines[: max_lines - 1]),
+            *ellipsis.render(console),
+            Segment.line(),
+        ]
+    )
 
 
 def measure_width(obj: object, console: Console) -> int:

--- a/src/textual_fastdatatable/format.py
+++ b/src/textual_fastdatatable/format.py
@@ -9,6 +9,7 @@ from rich.console import Console, RenderableType
 from rich.errors import MarkupError
 from rich.markup import escape
 from rich.protocol import is_renderable
+from rich.segment import Segment, Segments
 from rich.text import Text
 
 from textual_fastdatatable.column import Column
@@ -104,6 +105,38 @@ def cell_formatter(
 
     else:
         return cast(RenderableType, obj)
+
+
+def truncate_renderable(
+    renderable: RenderableType, console: Console, max_width: int, max_lines: int
+) -> RenderableType:
+    """Clip a renderable so it fits in a box of max_width x max_lines.
+
+    Args:
+        renderable: A Rich renderable.
+        console: The console used to render the renderable.
+        max_width: The width (in cells) the renderable will be rendered at.
+        max_lines: The maximum number of lines the returned renderable may occupy.
+
+    Returns:
+        The original renderable, if it already fits; otherwise a renderable of
+        exactly max_lines lines, the last of which marks the content as truncated.
+    """
+    if max_lines < 2 or max_width < 1:
+        return renderable
+    options = console.options.update(width=max_width, height=None, overflow="fold")
+    lines = console.render_lines(renderable, options, pad=False, new_lines=False)
+    if len(lines) <= max_lines:
+        return renderable
+
+    ellipsis = Text("… (truncated)", style="italic dim", no_wrap=True)
+    segments: list[Segment] = []
+    for line in [*lines[: max_lines - 1], list(ellipsis.render(console))]:
+        segments.extend(line)
+        # every line needs its newline: Textual sizes a renderable by counting
+        # the newlines in it, and would otherwise clip the last line.
+        segments.append(Segment.line())
+    return Segments(segments)
 
 
 def measure_width(obj: object, console: Console) -> int:

--- a/tests/unit_tests/test_tooltips.py
+++ b/tests/unit_tests/test_tooltips.py
@@ -28,6 +28,18 @@ class TooltipApp(App):
         yield DataTable(data={"json": [self.value] * 40}, max_column_content_width=20)
 
 
+class RestyledTooltipApp(TooltipApp):
+    """An app that restyles the tooltip, the way harlequin does."""
+
+    CSS = """
+    Tooltip {
+        max-width: 72;
+        padding: 0 1;
+        margin: 2 0;
+    }
+    """
+
+
 class HoverResult(NamedTuple):
     """The state of a tooltip while its app was still running."""
 
@@ -89,6 +101,24 @@ async def test_long_value_tooltip_is_marked_truncated() -> None:
     # so without the last one the truncation marker would be clipped
     assert len(text.splitlines()) == text.count("\n")
     assert result.region.height >= len(text.splitlines())
+
+
+@pytest.mark.asyncio
+async def test_tooltip_is_measured_from_the_tooltip_widgets_own_styles() -> None:
+    """An app may restyle the tooltip; its size must not be assumed."""
+    app = RestyledTooltipApp(LONG_VALUE)
+    result = await _hover_middle_cell(app)
+    assert result.displayed
+    assert result.displayed_after_refresh
+    assert not result.region.contains_point(result.mouse_position)
+
+    assert isinstance(result.content, Segments)
+    text = "".join(segment.text for segment in result.content.segments)
+    lines = text.splitlines()
+    # the app's own max-width (72) and padding (0 1) are used, not Textual's
+    # default 40 with padding 1 2, which would wrap the content at 36 cells
+    assert result.region.width == 72
+    assert 36 < max(len(line) for line in lines) <= 70
 
 
 @pytest.mark.asyncio

--- a/tests/unit_tests/test_tooltips.py
+++ b/tests/unit_tests/test_tooltips.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import NamedTuple
+
+import pytest
+from rich.segment import Segments
+from textual.app import App, ComposeResult
+from textual.geometry import Offset, Region
+from textual.widgets import Tooltip
+
+from textual_fastdatatable import DataTable
+
+LONG_VALUE = json.dumps({f"key_{i}": f"value_{i}" * 5 for i in range(200)})
+TERMINAL_SIZE = (80, 24)
+
+
+class TooltipApp(App):
+    TOOLTIP_DELAY = 0.05
+
+    def __init__(self, value: str) -> None:
+        super().__init__()
+        self.value = value
+
+    def compose(self) -> ComposeResult:
+        # the tooltip only appears for values wider than the rendered column
+        yield DataTable(data={"json": [self.value] * 40}, max_column_content_width=20)
+
+
+class HoverResult(NamedTuple):
+    """The state of a tooltip while its app was still running."""
+
+    displayed: bool
+    displayed_after_refresh: bool
+    region: Region
+    mouse_position: Offset
+    content: object
+
+
+async def _hover_middle_cell(app: TooltipApp) -> HoverResult:
+    """Hover a cell halfway down the screen and observe the tooltip."""
+    async with app.run_test(tooltips=True, size=TERMINAL_SIZE) as pilot:
+        await pilot.hover(DataTable, offset=(2, TERMINAL_SIZE[1] // 2))
+        await asyncio.sleep(app.TOOLTIP_DELAY * 4)
+        await pilot.pause()
+        tooltip = app.screen.get_child_by_type(Tooltip)
+        displayed = tooltip.display
+        result = HoverResult(
+            displayed=displayed,
+            displayed_after_refresh=displayed,
+            region=tooltip.region,
+            mouse_position=app.mouse_position,
+            content=app.query_one(DataTable).tooltip,
+        )
+        # Textual re-checks the widget under the mouse after every layout
+        # refresh, and clears a tooltip that has covered its own widget.
+        app.screen.screen_layout_refresh_signal.publish(app.screen)
+        await pilot.pause()
+        return result._replace(displayed_after_refresh=tooltip.display)
+
+
+@pytest.mark.asyncio
+async def test_long_value_tooltip_does_not_cover_the_mouse() -> None:
+    """A tooltip that covers the mouse flickers forever.
+
+    Textual places the tooltip at the mouse and clamps it to the screen if it
+    fits neither below nor above; it then clears any tooltip that is no longer
+    under its own widget, so an oversized tooltip is shown and hidden over and
+    over. Regression test for https://github.com/tconbeer/harlequin/issues/894
+    """
+    app = TooltipApp(LONG_VALUE)
+    result = await _hover_middle_cell(app)
+    assert result.displayed, "no tooltip was shown for a long cell value"
+    assert result.region.height < TERMINAL_SIZE[1]
+    assert not result.region.contains_point(result.mouse_position)
+    assert result.displayed_after_refresh, "the tooltip was cleared, and will flicker"
+
+
+@pytest.mark.asyncio
+async def test_long_value_tooltip_is_marked_truncated() -> None:
+    app = TooltipApp(LONG_VALUE)
+    result = await _hover_middle_cell(app)
+    assert isinstance(result.content, Segments)
+    text = "".join(segment.text for segment in result.content.segments)
+    assert text.startswith('{"key_0"')
+    assert text.rstrip("\n").endswith("… (truncated)")
+    # every line ends in a newline; Textual sizes a renderable by counting them,
+    # so without the last one the truncation marker would be clipped
+    assert len(text.splitlines()) == text.count("\n")
+    assert result.region.height >= len(text.splitlines())
+
+
+@pytest.mark.asyncio
+async def test_short_value_tooltip_is_not_truncated() -> None:
+    """Values that fit are still passed to the tooltip unchanged."""
+    app = TooltipApp("a" * 30)
+    result = await _hover_middle_cell(app)
+    assert result.displayed
+    assert result.content is not None
+    assert not isinstance(result.content, Segments)


### PR DESCRIPTION
Fixes [tconbeer/harlequin#894](https://github.com/tconbeer/harlequin/issues/894): hovering a cell with a large value (a Postgres JSONB column, in the report) shows a tooltip that appears for a fraction of a second, disappears, and repeats indefinitely.

## Cause

Textual places a tooltip at the mouse and constrains it to the screen with `constrain: inside inflect` — it flips above the mouse when it does not fit below. A tooltip that fits on **neither** side is clamped inside the screen, where it covers the mouse. `Screen._maybe_clear_tooltip` then runs on the next layout refresh, sees the tooltip (not the table) under the mouse, and clears it; the mouse is over the cell again, the timer restarts, and it flickers forever.

## Fix

- `format.truncate_renderable()` renders any Rich renderable at the tooltip's content width and clips it to `max_lines`, ending with a dim `… (truncated)` marker. A renderable that already fits is returned untouched.
- `DataTable._max_tooltip_lines` caps content at `screen_height // 2 - 4` lines (floor of 2). Half the screen always fits on one side of the mouse, so the tooltip can no longer be clamped over it. The terminal height is part of the tooltip cache key, so a resize re-truncates.
- Long `str` values are sliced to `width * (max_lines + 1)` characters before formatting, so megabytes of JSON are not markup-parsed and rendered only to be discarded.

One non-obvious detail: Textual sizes a renderable by counting its newlines (`RichVisual.get_height`), so the clipped output ends **every** line, including the last, with one — otherwise the truncation marker is silently clipped off.

## What it looks like

Hovering a long JSONB cell in a 90x26 terminal (9 content lines = `26 // 2 - 4`):

```
  6  {"order_id": 41983, "customer":…  pending
                                        hipped
  {"order_id": 41983, "customer":       ending
  {"name": "Ada Lovelace", "tier":      hipped
  "gold", "since": "2019-03-11"},       ending
  "items": [{"sku": "SKU-0001", "qty":  hipped
  1, "price": 3.5}, {"sku":             ending
  "SKU-0002", "qty": 2, "price": 7.0},  hipped
  {"sku": "SKU-0003", "qty": 3,         ending
  "price": 10.5}, {"sku": "SKU-0004",   hipped
  … (truncated)                         ending
```

## Testing

`tests/unit_tests/test_tooltips.py` drives a real app with `tooltips=True`, hovers a cell mid-screen, and asserts the tooltip displays, does not cover the mouse, and survives a layout-refresh signal. Confirmed these fail with the truncation disabled, and that the height test fails when the trailing newline is dropped.

I also swept every mouse row at six terminal sizes (80x24, 80x25, 80x11, 80x8, 40x60, 120x40): no flicker anywhere. On an 8-row terminal two rows show no tooltip at all — not even a 2-line tooltip fits above or below the mouse there — but it no longer flickers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWC64M79px3K1BVupuSeS8