### PR TITLE
perf: make `textual_fastdatatable.backend` importable without Textual

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,137 @@
+# AGENTS.md
+
+This file provides guidance to coding agents (including Claude Code) when working with
+code in this repository.
+
+## Project
+
+`textual-fastdatatable` is a performance-focused reimplementation of Textual's built-in
+`DataTable` widget, with a pluggable data storage backend. It is a library (published to
+PyPI, consumed by [harlequin](https://github.com/tconbeer/harlequin)), not an application.
+The performance win comes from never materializing the whole dataset as Python objects:
+the data stays in a columnar store (Arrow or Polars) and only visible cells are converted
+and rendered.
+
+## Commands
+
+Dependency management is `uv`; every command runs through `uv run`.
+
+```bash
+make check        # sync deps, ruff format, pytest, ruff check --fix, mypy
+make lint         # same, without the tests
+make serve        # run the demo app (src/textual_fastdatatable/__main__.py) in textual dev mode
+make benchmark    # scripts/benchmark.py: this widget vs. Textual's built-in, over tests/data/*.parquet
+make profile      # pyinstrument HTML profile of a wide-table render
+
+uv run pytest tests/unit_tests/test_backends.py                    # one file
+uv run pytest tests/unit_tests/test_backends.py::test_get_cell_at  # one test
+uv run pytest -k "sort"                                            # by name
+uv run pytest --snapshot-update                                    # accept new snapshot SVGs
+```
+
+CI (`.github/workflows/test.yml`) runs `pytest` on Python 3.10–3.14 × Linux/macOS/Windows;
+`static.yml` runs `ruff format --diff`, `ruff check`, and `mypy --no-incremental`.
+
+## Architecture
+
+### Two layers: widget and backend
+
+`data_table.py` (~2800 lines) is a fork of Textual's `DataTable`, rewritten so that it
+holds no row/cell objects of its own. Instead it asks a `DataTableBackend` for values by
+integer index. There are no `RowKey`/`ColumnKey` identity objects as in upstream Textual —
+rows and columns are addressed positionally, which is why sorting invalidates caches via
+`_update_count` rather than remapping keys.
+
+`backend.py` defines the ABC `DataTableBackend[_TableTypeT]` plus two implementations:
+
+- `ArrowBackend` (pyarrow, always available) — also handles pandas DataFrames via
+  `pa.Table.from_pandas`, and parquet files via `pq.read_table`.
+- `PolarsBackend` — defined only when polars imports (`if _HAS_POLARS:` guard at module
+  level). It is the backend for CSV/JSON/IPC file paths, so those formats require the
+  `polars` extra.
+
+`create_backend()` is the dispatch point for `DataTable(data=...)`: it type-tests the input
+and picks a backend. Note `_is_pandas_dataframe` deliberately checks `sys.modules` instead
+of importing pandas — pandas is not a dependency of this package.
+
+The contract a backend must satisfy is narrow and index-based: `row_count`,
+`column_count`, `columns`, `column_content_widths`, `get_row_at`/`get_column_at`/
+`get_cell_at`, and the mutation methods (`append_rows`, `append_column`, `drop_row`,
+`update_cell`, `sort`). Mutations are implemented by rebuilding the immutable table
+(`pa.Table.from_batches`, `pl.concat`) and are expected to be slow; the design optimizes
+for large immutable data.
+
+`max_rows` truncates the displayed data while `source_data`/`source_row_count` keep
+reporting the full input — the widget shows both counts.
+
+### Column widths
+
+`column_content_widths` is the hot path for first paint. Each backend computes it with
+vectorized column operations rather than per-cell Python (`_measure`): booleans and nulls
+are constants, numerics measure only min/max, temporals measure one non-null value, and
+everything else casts the whole column to string and takes `max(utf8_length)`. The result
+is cached on the backend and cleared by `_reset_content_widths()` on mutation. The Arrow
+path registers a PyArrow scalar UDF as a fallback for types Arrow can't cast to string.
+
+`column.Column` turns those content widths into render widths (`+ CELL_X_PADDING`,
+clamped by `max_column_content_width` when set). It also detects ID-ish column names by
+regex so `format.cell_formatter` omits thousands separators for those integers.
+
+### Rendering and caches
+
+`format.cell_formatter` converts a raw Python value to a Rich renderable — right-aligning
+numbers/dates, locale-formatting via `{obj:n}` (callers should `locale.setlocale()` first),
+escaping or parsing markup depending on `render_markup`, and rendering `datetime.max`/
+`date.max` (produced by `_handle_overflow` when Arrow values overflow Python types) as ∞.
+
+The render path is `render_line` → `_render_line_in_row` → `_render_cell`, each backed by
+an `LRUCache` (`_line_cache`, `_row_render_cache`, `_cell_render_cache`, `_tooltip_cache`).
+Cache keys include `_update_count` and `_pseudo_class_state`, so **any state change that
+affects appearance must either be part of a cache key or call `_clear_caches()`** — a
+stale cell is the classic bug here. Dimension recalculation is deferred to `_on_idle` via
+`_require_update_dimensions`.
+
+### Divergences from upstream Textual DataTable
+
+Row heights are always 1 line; row labels are not supported (the related snapshot test is
+skipped). `cursor_type="range"` adds shift-based range selection and a `SelectionCopied`
+message on `ctrl+c`/`super+c` — this requires the host app to be built with
+`inherit_bindings=False`. Widget-emitted messages are nested classes on `DataTable`
+(`CellHighlighted`, `SelectionCopied`, `DataLoadError`, …); `DataLoadError` is posted from
+`__init__` when `create_backend` raises, leaving `self.backend is None`.
+
+## Conventions
+
+- mypy runs in strict mode over `src/` and `tests/unit_tests/`. Local pyarrow stubs live
+  in `stubs/` (`mypy_path = "stubs,src"`); if you touch a pyarrow API mypy doesn't know
+  about, add it to the stub rather than adding `# type: ignore`.
+- Backend tests use the `backend` fixture in `tests/conftest.py`, which is parametrized
+  over `ArrowBackend` and `PolarsBackend` — behavior changes should hold for both.
+- Snapshot tests (`tests/snapshot_tests/`) each mount a tiny app from `snapshot_apps/` and
+  compare rendered SVGs. Review diffs before running `--snapshot-update`.
+- `backend.py`, `format.py`, and `column.py` must stay free of Textual imports, so that
+  downstream consumers (harlequin's headless `hsql` CLI) can use `create_backend()`
+  without paying for the framework. Two deliberate deferrals keep this true, and **neither
+  is covered by a test** — adding a convenience import to the top of `__init__.py` silently
+  undoes the first, and any module-scope `pq.` use undoes the second:
+  - `__init__.py` imports `DataTable` lazily via a module-level `__getattr__` (PEP 562),
+    with a `TYPE_CHECKING` import so mypy still resolves it for downstream users.
+  - `pyarrow.parquet` is imported inside `ArrowBackend.from_parquet`, its only use site.
+    `pyarrow.compute`/`types`/`lib` stay at module scope; they're used in the hot path.
+
+  Check by hand after touching either file — both print `False`, and the import costs 186
+  modules on 3.10 against the required deps (523 with the `polars` extra, which `uv sync`
+  installs):
+
+  ```bash
+  uv run python -c "import sys; from textual_fastdatatable.backend import create_backend; print('textual' in sys.modules, 'pyarrow.parquet' in sys.modules, len(sys.modules))"
+  ```
+- `tests/unit_tests/test_wheels.py` resolves the dependency floors in `pyproject.toml` for
+  every supported Python/platform with wheels only. It shells out to `uv` and hits PyPI, so
+  it skips offline. Changing a dependency pin means checking this test.
+- The Textual version is pinned in three places that must move together: the `test`
+  dependency group, `.pre-commit-config.yaml`'s mypy `additional_dependencies`, and the
+  `textual>=` floor in `[project] dependencies`.
+- `CHANGELOG.md` follows keep-a-changelog; add user-facing changes under `## [Unreleased]`.
+  Releases are cut by the `release.yml` workflow (version bump on a `release/vX.Y.Z`
+  branch), which publishes on merge — do not bump the version by hand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- `textual_fastdatatable.backend` can now be imported without importing Textual: the
+  `DataTable` widget is now imported lazily by the package root (PEP 562), so
+  `from textual_fastdatatable.backend import create_backend` no longer drags in the widget
+  framework. `from textual_fastdatatable import DataTable` is unchanged, and still imports
+  Textual at the moment the name is accessed.
+- `pyarrow.parquet` is now imported lazily, inside `ArrowBackend.from_parquet()`, instead
+  of at module scope in `backend.py`.
+- Together these cut `from textual_fastdatatable.backend import create_backend` from 359
+  to 186 imported modules on Python 3.10 (measured against this project's required
+  dependencies, without the `polars` extra). There are no API changes.
+
 ## [0.16.0] - 2026-08-05
 
 ### Features

--- a/src/textual_fastdatatable/__init__.py
+++ b/src/textual_fastdatatable/__init__.py
@@ -1,9 +1,13 @@
+from typing import TYPE_CHECKING, Any
+
 from textual_fastdatatable.backend import (
     ArrowBackend,
     DataTableBackend,
     create_backend,
 )
-from textual_fastdatatable.data_table import DataTable
+
+if TYPE_CHECKING:
+    from textual_fastdatatable.data_table import DataTable
 
 __all__ = [
     "DataTable",
@@ -11,3 +15,17 @@ __all__ = [
     "DataTableBackend",
     "create_backend",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily import the DataTable widget (PEP 562).
+
+    Importing the widget imports Textual; keeping it out of module scope means
+    `textual_fastdatatable.backend` can be imported without paying for the
+    framework.
+    """
+    if name == "DataTable":
+        from textual_fastdatatable.data_table import DataTable
+
+        return DataTable
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/textual_fastdatatable/backend.py
+++ b/src/textual_fastdatatable/backend.py
@@ -11,7 +11,6 @@ from typing import Any, Generic, Literal, TypeVar
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.lib as pal
-import pyarrow.parquet as pq
 import pyarrow.types as pt
 from rich.console import Console
 
@@ -273,6 +272,10 @@ class ArrowBackend(DataTableBackend[pa.Table]):
     def from_parquet(
         cls, path: Path | str, max_rows: int | None = None
     ) -> "ArrowBackend":
+        # deferred: parquet is the only pyarrow submodule not used elsewhere in
+        # this module, and it is expensive to import.
+        import pyarrow.parquet as pq
+
         tbl = pq.read_table(str(path))
         return cls(tbl, max_rows=max_rows)
 


### PR DESCRIPTION
Closes #162.

`backend.py`, `format.py` and `column.py` have no Textual references, but `__init__.py` imported the `DataTable` widget eagerly, so reaching the backend pulled in the whole framework. This defers that import, and `pyarrow.parquet` along with it.

Two commits: the refactor, and the AGENTS.md doc.

## Change 1 — lazy `DataTable` in `__init__.py`

A module-level `__getattr__` (PEP 562). The three backend names stay eager — they're cheap and Textual-free. The `TYPE_CHECKING` import is what keeps mypy resolving `DataTable` for downstream users, and the `AttributeError` message matches CPython's default, so nothing downstream can tell the difference.

## Change 2 — defer `pyarrow.parquet`

Moved into `ArrowBackend.from_parquet`, its only use site (`pq.` appears nowhere else in the file). `pyarrow.compute`/`types`/`lib` are left at module scope, per the issue — they're used throughout `_measure`, `_handle_overflow` and `sort`.

## Measurements

`from textual_fastdatatable.backend import create_backend`, Python 3.10, against this project's **required** dependencies (no `polars` extra):

| | modules | textual | pyarrow.parquet |
| --- | --- | --- | --- |
| before | 359 | yes | yes |
| after | **186** | no | no |

The remaining 186 is 41 interpreter baseline + 41 `rich` + 11 `pyarrow` + the rest. That's 3 above the 183 the issue predicted — most likely a dependency patch-version difference from the prototype, which the issue anticipated ("exact count varies").

Worth knowing for anyone re-measuring: with the `polars` extra installed — which `uv sync --group test` does — the same import costs **523** modules, because `backend.py` imports polars when it's available (167 polars + 85 numpy). The count is only meaningful in a polars-free environment.

## Acceptance criteria

All verified. `make check` is green: 87 passed, 4 skipped (pre-existing skips), `ruff format`/`ruff check` clean, `mypy` clean. The snapshot tests pass, which exercises the widget and so proves the lazy path resolves. I also checked mypy resolves `DataTable` and `t.backend` through the package root for a downstream consumer, and confirmed `from textual_fastdatatable import Nope` raises the standard `AttributeError`.

No public API changes: `__all__` is unchanged, no signatures change, nothing renamed or removed.

## Deviation from the issue: no regression test

The issue asked for `tests/unit_tests/test_import_isolation.py`. I wrote it — five subprocess-based checks, three of which failed on `main` and passed on the branch — and then **removed it at @tconbeer's direction**, on the basis that the documentation is sufficient now that the behavior is confirmed.

So this lands with no mechanical guard. A convenience import added to the top of `__init__.py`, or any module-scope `pq.` use, silently reverts it. The AGENTS.md commit documents both deferrals, says explicitly that neither is covered by a test, and gives the one-liner to check by hand:

```bash
uv run python -c "import sys; from textual_fastdatatable.backend import create_backend; print('textual' in sys.modules, 'pyarrow.parquet' in sys.modules, len(sys.modules))"
```

The test is recoverable from this branch's history if you want it back later.


---
_Generated by [Claude Code](https://claude.ai/code/session_013JTG1PUREL3wpzMvRv8vYy)_