### PR TITLE
feat: accept the caller's column names in create_backend()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,13 @@ rows and columns are addressed positionally, which is why sorting invalidates ca
 and picks a backend. Note `_is_pandas_dataframe` deliberately checks `sys.modules` instead
 of importing pandas — pandas is not a dependency of this package.
 
+Its optional `column_names` argument carries labels the caller has but the data doesn't
+(a cursor description, say). It is threaded down to each backend's `__init__` and applied
+*before* the duplicate-name de-duplication, so `ArrowBackend.source_data` keeps duplicates
+verbatim while `.data` gets `a`, `a0`. `_relabel` holds the rules: no columns at all means
+build an empty table from the names; one name per column means rename; any other count
+means the data's own names win.
+
 The contract a backend must satisfy is narrow and index-based: `row_count`,
 `column_count`, `columns`, `column_content_widths`, `get_row_at`/`get_column_at`/
 `get_cell_at`, and the mutation methods (`append_rows`, `append_column`, `drop_row`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 - `create_backend()` (and the backend constructors it dispatches to) now accept a
   `column_names` argument: the labels the caller has for the data's columns, which are
   applied in place of the ones the data carries or lacks
-  ([tconbeer/harlequin#524](https://github.com/tconbeer/harlequin/issues/524)).
+  ([#165](https://github.com/tconbeer/textual-fastdatatable/issues/165)).
   - `create_backend(None, column_names=[...])` builds an empty table with those columns
     instead of raising `TypeError`; so does an empty sequence, or any table with no
     columns at all.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,10 @@ All notable changes to this project will be documented in this file.
 
 - `create_backend()` (and the backend constructors it dispatches to) now accept a
   `column_names` argument: the labels the caller has for the data's columns, which are
-  applied in place of the ones the data carries or lacks
+  applied in place of the ones the data carries or lacks. `create_backend(None,
+  column_names=[...])` now builds an empty table with those columns instead of raising,
+  and records use those names in place of `f0`, `f1`, ...
   ([#165](https://github.com/tconbeer/textual-fastdatatable/issues/165)).
-  - `create_backend(None, column_names=[...])` builds an empty table with those columns
-    instead of raising `TypeError`; so does an empty sequence, or any table with no
-    columns at all.
-  - Record-shaped data uses those names in place of `f0`, `f1`, .... If `has_header=True`
-    is also passed, the first record is still consumed as a header, but `column_names`
-    wins over it.
-  - Tabular data (Arrow, polars, pandas, parquet, CSV, a pydict) is renamed when there is
-    one name per column; a mismatched count leaves the data's own names in place.
-  - Duplicate names (`select 1 as a, 2 as a`) reach `ArrowBackend.source_data` verbatim.
-    `ArrowBackend.data` still de-duplicates them to `a`, `a0` for display.
-  - Omitting `column_names` leaves every existing behavior unchanged.
-- Fixes `tests/unit_tests/test_arrow_backend.py::test_from_parquet`, which broke in 0.16.1
-  when `pyarrow.parquet` became a lazy import.
 
 ## [0.16.1] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- `create_backend()` (and the backend constructors it dispatches to) now accept a
+  `column_names` argument: the labels the caller has for the data's columns, which are
+  applied in place of the ones the data carries or lacks
+  ([tconbeer/harlequin#524](https://github.com/tconbeer/harlequin/issues/524)).
+  - `create_backend(None, column_names=[...])` builds an empty table with those columns
+    instead of raising `TypeError`; so does an empty sequence, or any table with no
+    columns at all.
+  - Record-shaped data uses those names in place of `f0`, `f1`, .... If `has_header=True`
+    is also passed, the first record is still consumed as a header, but `column_names`
+    wins over it.
+  - Tabular data (Arrow, polars, pandas, parquet, CSV, a pydict) is renamed when there is
+    one name per column; a mismatched count leaves the data's own names in place.
+  - Duplicate names (`select 1 as a, 2 as a`) reach `ArrowBackend.source_data` verbatim.
+    `ArrowBackend.data` still de-duplicates them to `a`, `a0` for display.
+  - Omitting `column_names` leaves every existing behavior unchanged.
+- Fixes `tests/unit_tests/test_arrow_backend.py::test_from_parquet`, which broke in 0.16.1
+  when `pyarrow.parquet` became a lazy import.
+
 ## [0.16.1] - 2026-08-07
 
 - `textual_fastdatatable.backend` can now be imported without importing Textual: the

--- a/README.md
+++ b/README.md
@@ -100,6 +100,32 @@ backend = ArrowBackend.from_records(
 backend = ArrowBackend.from_parquet("path/to/file.parquet")
 ```
 
+### Supplying column names
+
+If you have names for the columns that the data itself doesn't carry — a database cursor's
+description, say — pass them to `create_backend` as `column_names`:
+
+```py
+from textual_fastdatatable import create_backend
+backend = create_backend([(1, "a"), (2, "b")], column_names=["id", "letter"])
+backend.columns  # ["id", "letter"], instead of ["f0", "f1"]
+```
+
+They also let a query that returned no rows keep its header, which is otherwise impossible
+to express:
+
+```py
+create_backend(None)                              # raises TypeError
+create_backend(None, column_names=["id", "letter"]).columns  # ["id", "letter"]
+create_backend([], column_names=["id", "letter"]).columns    # ["id", "letter"]
+```
+
+For data that already has columns (an Arrow table, a DataFrame, a Parquet or CSV file, a
+dict), the names are applied when there is one for each column; a mismatched count leaves
+the data's own names alone. Duplicate names are allowed — `select 1 as a, 2 as a` is legal
+SQL — and reach `ArrowBackend.source_data` verbatim, though `ArrowBackend.data` (what the
+widget displays) de-duplicates them to `a`, `a0`.
+
 ## Limitations and Caveats
 
 The `DataTable` does not currently support rows with a height of more than one line. Only the first line of each row will be displayed.

--- a/src/textual_fastdatatable/backend.py
+++ b/src/textual_fastdatatable/backend.py
@@ -31,35 +31,78 @@ def create_backend(
     data: "AutoBackendType",
     max_rows: int | None = None,
     has_header: bool = False,
+    column_names: Sequence[str] | None = None,
 ) -> DataTableBackend:
+    """Create a backend for `data`, picking the implementation from its type.
+
+    column_names: the labels the caller has for the data's columns, which are
+        applied to the backend in place of the ones the data carries (or lacks).
+        When passed:
+
+        - `data=None` builds an empty table with those columns, instead of
+          raising: a cursor that returned no rows still described its columns.
+        - `data` an empty sequence (or any table with no columns at all) builds
+          an empty table with those columns.
+        - record-shaped `data` uses them in place of `f0`, `f1`, .... If
+          `has_header` is also set, the first record is still consumed as a
+          header, but these names win over it.
+        - tabular `data` is renamed to them when there is one name per column.
+          A mismatched count means the data and the names disagree, and the data
+          wins.
+
+        Duplicate names are legal (`select 1 as a, 2 as a`) and reach
+        `ArrowBackend.source_data` verbatim. `ArrowBackend.data` de-duplicates
+        them (to `a`, `a0`), because a table's `to_pylist()`/`to_pydict()` drop
+        duplicate-named fields; `PolarsBackend` de-duplicates them everywhere,
+        as polars does not allow duplicate column names at all.
+
+        When `column_names` is not passed, every case behaves as it always has.
+    """
+    if data is None and column_names is not None:
+        return ArrowBackend(_empty_table(column_names), max_rows=max_rows)
     if isinstance(data, pa.Table):
-        return ArrowBackend(data, max_rows=max_rows)
+        return ArrowBackend(data, max_rows=max_rows, column_names=column_names)
     if isinstance(data, pa.RecordBatch):
-        return ArrowBackend.from_batches(data, max_rows=max_rows)
+        return ArrowBackend.from_batches(
+            data, max_rows=max_rows, column_names=column_names
+        )
     if _HAS_POLARS and isinstance(data, pl.DataFrame):
-        return PolarsBackend.from_dataframe(data, max_rows=max_rows)
+        return PolarsBackend.from_dataframe(
+            data, max_rows=max_rows, column_names=column_names
+        )
     if _is_pandas_dataframe(data):
-        return ArrowBackend.from_pandas(data, max_rows=max_rows)
+        return ArrowBackend.from_pandas(
+            data, max_rows=max_rows, column_names=column_names
+        )
 
     if isinstance(data, Path) or isinstance(data, str):
         data = Path(data)
         if data.suffix in [".pqt", ".parquet"]:
-            return ArrowBackend.from_parquet(data, max_rows=max_rows)
+            return ArrowBackend.from_parquet(
+                data, max_rows=max_rows, column_names=column_names
+            )
         if _HAS_POLARS:
             return PolarsBackend.from_file_path(
-                data, max_rows=max_rows, has_header=has_header
+                data,
+                max_rows=max_rows,
+                has_header=has_header,
+                column_names=column_names,
             )
     if isinstance(data, Sequence) and not data:
-        return ArrowBackend(pa.table([]), max_rows=max_rows)
+        return ArrowBackend(pa.table([]), max_rows=max_rows, column_names=column_names)
     if isinstance(data, Sequence) and _is_iterable(data[0]):
-        return ArrowBackend.from_records(data, max_rows=max_rows, has_header=has_header)
+        return ArrowBackend.from_records(
+            data, max_rows=max_rows, has_header=has_header, column_names=column_names
+        )
 
     if (
         isinstance(data, Mapping)
         and isinstance(next(iter(data.keys())), str)
         and isinstance(next(iter(data.values())), Sequence)
     ):
-        return ArrowBackend.from_pydict(data, max_rows=max_rows)
+        return ArrowBackend.from_pydict(
+            data, max_rows=max_rows, column_names=column_names
+        )
 
     raise TypeError(
         f"Cannot automatically create backend for data of type: {type(data)}. "
@@ -67,6 +110,44 @@ def create_backend(
         "Sequence[Iterable[Any]], Mapping[str, Sequence[Any]], pl.DataFrame, "
         "pd.DataFrame",
     )
+
+
+def _empty_table(column_names: Sequence[str]) -> pa.Table:
+    """A table with the passed columns and no rows."""
+    return pa.Table.from_arrays(
+        [pa.array([], type=pa.string()) for _ in column_names],
+        names=list(column_names),
+    )
+
+
+def _relabel(data: pa.Table, column_names: Sequence[str]) -> pa.Table:
+    """Apply the caller's column names to an Arrow table.
+
+    A table with no columns described nothing, so it is replaced by an empty
+    table with the caller's columns. Otherwise the names are applied only if
+    there is one for each column: a mismatched count means the data and the
+    names disagree, and the data's own names win.
+    """
+    names = list(column_names)
+    if data.num_columns == 0:
+        return _empty_table(names)
+    if data.num_columns != len(names):
+        return data
+    return data.rename_columns(names)
+
+
+def _deduplicate(column_names: Sequence[str]) -> tuple[list[str], bool]:
+    """Make each name unique by suffixing repeats; also report if any changed."""
+    field_names: list[str] = []
+    renamed = False
+    for field in column_names:
+        n = 0
+        while field in field_names:
+            field = f"{field}{n}"
+            renamed = True
+            n += 1
+        field_names.append(field)
+    return field_names, renamed
 
 
 def _is_pandas_dataframe(data: Any) -> bool:
@@ -95,13 +176,21 @@ class DataTableBackend(ABC, Generic[_TableTypeT]):
     data: _TableTypeT
 
     @abstractmethod
-    def __init__(self, data: _TableTypeT, max_rows: int | None = None) -> None:
+    def __init__(
+        self,
+        data: _TableTypeT,
+        max_rows: int | None = None,
+        column_names: Sequence[str] | None = None,
+    ) -> None:
         pass
 
     @classmethod
     @abstractmethod
     def from_pydict(
-        cls, data: Mapping[str, Sequence[Any]], max_rows: int | None = None
+        cls,
+        data: Mapping[str, Sequence[Any]],
+        max_rows: int | None = None,
+        column_names: Sequence[str] | None = None,
     ) -> "DataTableBackend":
         pass
 
@@ -197,20 +286,21 @@ class DataTableBackend(ABC, Generic[_TableTypeT]):
 
 
 class ArrowBackend(DataTableBackend[pa.Table]):
-    def __init__(self, data: pa.Table, max_rows: int | None = None) -> None:
+    def __init__(
+        self,
+        data: pa.Table,
+        max_rows: int | None = None,
+        column_names: Sequence[str] | None = None,
+    ) -> None:
+        # the caller's names are applied first, so that source_data carries them
+        # verbatim, duplicates and all.
+        if column_names is not None:
+            data = _relabel(data, column_names)
         self._source_data = data
 
         # Arrow allows duplicate field names, but a table's to_pylist() and
         # to_pydict() methods will drop duplicate-named fields!
-        field_names: list[str] = []
-        renamed = False
-        for field in data.column_names:
-            n = 0
-            while field in field_names:
-                field = f"{field}{n}"
-                renamed = True
-                n += 1
-            field_names.append(field)
+        field_names, renamed = _deduplicate(data.column_names)
         if renamed:
             data = data.rename_columns(field_names)
 
@@ -263,35 +353,49 @@ class ArrowBackend(DataTableBackend[pa.Table]):
 
     @classmethod
     def from_batches(
-        cls, data: pa.RecordBatch, max_rows: int | None = None
+        cls,
+        data: pa.RecordBatch,
+        max_rows: int | None = None,
+        column_names: Sequence[str] | None = None,
     ) -> "ArrowBackend":
         tbl = pa.Table.from_batches([data])
-        return cls(tbl, max_rows=max_rows)
+        return cls(tbl, max_rows=max_rows, column_names=column_names)
 
     @classmethod
     def from_parquet(
-        cls, path: Path | str, max_rows: int | None = None
+        cls,
+        path: Path | str,
+        max_rows: int | None = None,
+        column_names: Sequence[str] | None = None,
     ) -> "ArrowBackend":
         # deferred: parquet is the only pyarrow submodule not used elsewhere in
         # this module, and it is expensive to import.
         import pyarrow.parquet as pq
 
         tbl = pq.read_table(str(path))
-        return cls(tbl, max_rows=max_rows)
+        return cls(tbl, max_rows=max_rows, column_names=column_names)
 
     @classmethod
-    def from_pandas(cls, frame: Any, max_rows: int | None = None) -> "ArrowBackend":
+    def from_pandas(
+        cls,
+        frame: Any,
+        max_rows: int | None = None,
+        column_names: Sequence[str] | None = None,
+    ) -> "ArrowBackend":
         """Create a backend from a pandas DataFrame.
 
         The frame's index is not displayed; call `df.reset_index()` first to
         show it as a column.
         """
         tbl = pa.Table.from_pandas(frame, preserve_index=False)
-        return cls(tbl, max_rows=max_rows)
+        return cls(tbl, max_rows=max_rows, column_names=column_names)
 
     @classmethod
     def from_pydict(
-        cls, data: Mapping[str, Sequence[Any]], max_rows: int | None = None
+        cls,
+        data: Mapping[str, Sequence[Any]],
+        max_rows: int | None = None,
+        column_names: Sequence[str] | None = None,
     ) -> "ArrowBackend":
         try:
             tbl = pa.Table.from_pydict(dict(data))
@@ -303,7 +407,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
                 for k, v in data.items()
             }
             tbl = pa.Table.from_pydict(new_data)
-        return cls(tbl, max_rows=max_rows)
+        return cls(tbl, max_rows=max_rows, column_names=column_names)
 
     @classmethod
     def from_records(
@@ -311,9 +415,12 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         records: Sequence[Iterable[Any]],
         has_header: bool = False,
         max_rows: int | None = None,
+        column_names: Sequence[str] | None = None,
     ) -> "ArrowBackend":
+        # column_names are applied by __init__, after the table is built: a
+        # pydict keyed by them would drop any duplicates among them.
         pydict = cls._pydict_from_records(records, has_header)
-        return cls.from_pydict(pydict, max_rows=max_rows)
+        return cls.from_pydict(pydict, max_rows=max_rows, column_names=column_names)
 
     @property
     def source_data(self) -> pa.Table:
@@ -511,7 +618,11 @@ if _HAS_POLARS:
     class PolarsBackend(DataTableBackend[pl.DataFrame]):
         @classmethod
         def from_file_path(
-            cls, path: Path, max_rows: int | None = None, has_header: bool = True
+            cls,
+            path: Path,
+            max_rows: int | None = None,
+            has_header: bool = True,
+            column_names: Sequence[str] | None = None,
         ) -> "PolarsBackend":
             if path.suffix in [".arrow", ".feather"]:
                 tbl = pl.read_ipc(path)
@@ -525,32 +636,47 @@ if _HAS_POLARS:
                 raise TypeError(
                     f"Dont know how to load file type {path.suffix} for {path}"
                 )
-            return cls(tbl, max_rows=max_rows)
+            return cls(tbl, max_rows=max_rows, column_names=column_names)
 
         @classmethod
         def from_pydict(
-            cls, pydict: Mapping[str, Sequence[Any]], max_rows: int | None = None
+            cls,
+            pydict: Mapping[str, Sequence[Any]],
+            max_rows: int | None = None,
+            column_names: Sequence[str] | None = None,
         ) -> "PolarsBackend":
-            return cls(pl.from_dict(pydict), max_rows=max_rows)
+            return cls(
+                pl.from_dict(pydict), max_rows=max_rows, column_names=column_names
+            )
 
         @classmethod
         def from_dataframe(
-            cls, frame: pl.DataFrame, max_rows: int | None = None
+            cls,
+            frame: pl.DataFrame,
+            max_rows: int | None = None,
+            column_names: Sequence[str] | None = None,
         ) -> "PolarsBackend":
-            return cls(frame, max_rows=max_rows)
+            return cls(frame, max_rows=max_rows, column_names=column_names)
 
-        def __init__(self, data: pl.DataFrame, max_rows: int | None = None) -> None:
+        def __init__(
+            self,
+            data: pl.DataFrame,
+            max_rows: int | None = None,
+            column_names: Sequence[str] | None = None,
+        ) -> None:
             self._source_data = data
 
+            names = list(data.columns)
+            # a mismatched count means the data and the caller's names disagree;
+            # the data wins.
+            if column_names is not None and len(column_names) == len(names):
+                names = list(column_names)
+
             # Arrow allows duplicate field names, but a table's to_pylist() and
-            # to_pydict() methods will drop duplicate-named fields!
-            field_names: list[str] = []
-            for field in data.columns:
-                n = 0
-                while field in field_names:
-                    field = f"{field}{n}"
-                    n += 1
-                field_names.append(field)
+            # to_pydict() methods will drop duplicate-named fields! polars does
+            # not allow them at all, so this de-duplication also reaches
+            # source_data, which is the same frame.
+            field_names, _ = _deduplicate(names)
             data.columns = field_names
 
             self._source_row_count = len(data)

--- a/tests/unit_tests/test_arrow_backend.py
+++ b/tests/unit_tests/test_arrow_backend.py
@@ -5,10 +5,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pyarrow as pa
-
-# pyarrow.parquet is imported lazily by ArrowBackend.from_parquet, so `pa.parquet`
-# is not bound until something imports it.
-import pyarrow.parquet  # noqa: F401
+import pyarrow.parquet as pq
 
 from textual_fastdatatable import ArrowBackend
 
@@ -46,7 +43,7 @@ def test_from_pydict_with_limit(pydict: dict[str, Sequence[str | int]]) -> None:
 def test_from_parquet(pydict: dict[str, Sequence[str | int]], tmp_path: Path) -> None:
     tbl = pa.Table.from_pydict(pydict)
     p = tmp_path / "test.parquet"
-    pa.parquet.write_table(tbl, str(p))
+    pq.write_table(tbl, str(p))
 
     backend = ArrowBackend.from_parquet(p)
     assert backend.data.equals(tbl)

--- a/tests/unit_tests/test_arrow_backend.py
+++ b/tests/unit_tests/test_arrow_backend.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 import pyarrow as pa
 
+# pyarrow.parquet is imported lazily by ArrowBackend.from_parquet, so `pa.parquet`
+# is not bound until something imports it.
+import pyarrow.parquet  # noqa: F401
+
 from textual_fastdatatable import ArrowBackend
 
 

--- a/tests/unit_tests/test_create_backend.py
+++ b/tests/unit_tests/test_create_backend.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import polars as pl
 import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from textual_fastdatatable.backend import ArrowBackend, PolarsBackend, create_backend
@@ -162,8 +163,6 @@ def test_csv_with_column_names(tmp_path: Path) -> None:
 
 
 def test_parquet_with_column_names(tmp_path: Path) -> None:
-    import pyarrow.parquet as pq
-
     path = tmp_path / "data.parquet"
     pq.write_table(pa.table({"a": [1, 2], "b": [3, 4]}), str(path))
     backend = create_backend(data=path, column_names=["one", "two"])

--- a/tests/unit_tests/test_create_backend.py
+++ b/tests/unit_tests/test_create_backend.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 from datetime import date, datetime
+from pathlib import Path
 
+import polars as pl
 import pyarrow as pa
+import pytest
 
-from textual_fastdatatable.backend import create_backend
+from textual_fastdatatable.backend import ArrowBackend, PolarsBackend, create_backend
 
 MAX_32BIT_INT = 2**31 - 1
 MAX_64BIT_INT = 2**63 - 1
@@ -15,6 +20,155 @@ def test_empty_sequence() -> None:
     assert backend.column_count == 0
     assert backend.columns == []
     assert backend.column_content_widths == []
+
+
+def test_none_without_column_names() -> None:
+    with pytest.raises(TypeError):
+        create_backend(data=None)
+
+
+@pytest.mark.parametrize("data", [None, [], ()])
+def test_no_data_with_column_names(data: None | list | tuple) -> None:
+    backend = create_backend(data=data, column_names=["a", "b"])
+    assert backend.row_count == 0
+    assert backend.column_count == 2
+    assert list(backend.columns) == ["a", "b"]
+    assert backend.column_content_widths == [0, 0]
+
+
+def test_no_data_with_empty_column_names() -> None:
+    backend = create_backend(data=None, column_names=[])
+    assert backend.row_count == 0
+    assert backend.column_count == 0
+    assert list(backend.columns) == []
+
+
+def test_records_with_column_names() -> None:
+    backend = create_backend(data=[(1, "x"), (2, "y")], column_names=["one", "two"])
+    assert list(backend.columns) == ["one", "two"]
+    assert backend.row_count == 2
+    assert backend.get_row_at(0) == [1, "x"]
+    assert backend.get_column_at(1) == ["x", "y"]
+
+
+def test_records_without_column_names() -> None:
+    backend = create_backend(data=[(1, "x"), (2, "y")])
+    assert list(backend.columns) == ["f0", "f1"]
+
+
+def test_records_with_column_names_wins_over_header() -> None:
+    """The header row is still consumed; the caller's names win over it."""
+    backend = create_backend(
+        data=[("h1", "h2"), (1, "x"), (2, "y")],
+        has_header=True,
+        column_names=["one", "two"],
+    )
+    assert list(backend.columns) == ["one", "two"]
+    assert backend.row_count == 2
+    assert backend.get_row_at(0) == [1, "x"]
+
+
+def test_records_with_mismatched_column_names() -> None:
+    backend = create_backend(data=[(1, "x"), (2, "y")], column_names=["only one"])
+    assert list(backend.columns) == ["f0", "f1"]
+
+
+def test_arrow_table_with_column_names() -> None:
+    backend = create_backend(
+        data=pa.table({"a": [1, 2], "b": [3, 4]}), column_names=["one", "two"]
+    )
+    assert list(backend.columns) == ["one", "two"]
+    assert list(backend.source_data.column_names) == ["one", "two"]
+    assert backend.get_row_at(0) == [1, 3]
+
+
+def test_arrow_table_with_mismatched_column_names() -> None:
+    """A mismatch means a misbehaving caller; the data's own names win."""
+    data = pa.table({"a": [1, 2], "b": [3, 4]})
+    backend = create_backend(data=data, column_names=["one", "two", "three"])
+    assert list(backend.columns) == ["a", "b"]
+    assert backend.get_row_at(0) == [1, 3]
+
+
+def test_arrow_table_without_columns_with_column_names() -> None:
+    backend = create_backend(data=pa.table([]), column_names=["a", "b"])
+    assert list(backend.columns) == ["a", "b"]
+    assert backend.row_count == 0
+
+
+def test_record_batch_with_column_names() -> None:
+    batch = pa.RecordBatch.from_pydict({"a": [1, 2], "b": [3, 4]})
+    backend = create_backend(data=batch, column_names=["one", "two"])
+    assert list(backend.columns) == ["one", "two"]
+    assert backend.get_row_at(1) == [2, 4]
+
+
+def test_pydict_with_column_names() -> None:
+    backend = create_backend(data={"a": [1, 2], "b": [3, 4]}, column_names=["one", "b"])
+    assert list(backend.columns) == ["one", "b"]
+    assert backend.get_row_at(0) == [1, 3]
+
+
+def test_duplicate_column_names_reach_source_data() -> None:
+    """`select 1 as a, 2 as a` is legal SQL; source_data keeps both names."""
+    backend = create_backend(data=[(1, 2)], column_names=["a", "a"])
+    assert isinstance(backend, ArrowBackend)
+    assert list(backend.source_data.column_names) == ["a", "a"]
+    # display needs unique names, so backend.data de-duplicates them
+    assert list(backend.columns) == ["a", "a0"]
+    assert backend.get_row_at(0) == [1, 2]
+
+
+def test_duplicate_column_names_from_arrow_table() -> None:
+    data = pa.Table.from_arrays([pa.array([1]), pa.array([2])], names=["x", "y"])
+    backend = create_backend(data=data, column_names=["a", "a"])
+    assert isinstance(backend, ArrowBackend)
+    assert list(backend.source_data.column_names) == ["a", "a"]
+    assert list(backend.columns) == ["a", "a0"]
+
+
+def test_column_names_with_max_rows() -> None:
+    backend = create_backend(
+        data=[(1, "x"), (2, "y"), (3, "z")], max_rows=2, column_names=["one", "two"]
+    )
+    assert list(backend.columns) == ["one", "two"]
+    assert backend.row_count == 2
+    assert backend.source_row_count == 3
+
+
+def test_polars_dataframe_with_column_names() -> None:
+    backend = create_backend(
+        data=pl.DataFrame({"a": [1, 2], "b": [3, 4]}), column_names=["one", "two"]
+    )
+    assert isinstance(backend, PolarsBackend)
+    assert list(backend.columns) == ["one", "two"]
+    assert backend.get_row_at(0) == [1, 3]
+
+
+def test_polars_dataframe_with_mismatched_column_names() -> None:
+    backend = create_backend(
+        data=pl.DataFrame({"a": [1, 2], "b": [3, 4]}), column_names=["one"]
+    )
+    assert list(backend.columns) == ["a", "b"]
+
+
+def test_csv_with_column_names(tmp_path: Path) -> None:
+    path = tmp_path / "headerless.csv"
+    path.write_text("1,x\n2,y\n")
+    backend = create_backend(data=path, has_header=False, column_names=["one", "two"])
+    assert isinstance(backend, PolarsBackend)
+    assert list(backend.columns) == ["one", "two"]
+    assert backend.row_count == 2
+
+
+def test_parquet_with_column_names(tmp_path: Path) -> None:
+    import pyarrow.parquet as pq
+
+    path = tmp_path / "data.parquet"
+    pq.write_table(pa.table({"a": [1, 2], "b": [3, 4]}), str(path))
+    backend = create_backend(data=path, column_names=["one", "two"])
+    assert list(backend.columns) == ["one", "two"]
+    assert backend.row_count == 2
 
 
 def test_infinity_timestamps() -> None:


### PR DESCRIPTION
Closes #165.

Adds an optional `column_names: Sequence[str] | None` to `create_backend()` and to the backend constructors it dispatches to. It carries the labels a caller has for the data's columns when the data itself doesn't carry them — a database cursor description, say — so callers no longer have to reconcile names against the backend afterwards.

Purely additive: omitting the argument leaves every existing path byte-identical.

## Behavior

| input | with `column_names` |
| --- | --- |
| `None` | empty table with those columns (was `TypeError`) |
| `[]`, `()`, `pa.table([])` | empty table with those columns (was a table with no columns) |
| records (`Sequence[Iterable]`) | those names instead of `f0`, `f1`, … |
| `pa.Table` / `pa.RecordBatch` / pandas / parquet / pydict | renamed when there is one name per column; on a mismatched count the data's own names win |
| `pl.DataFrame` / CSV, JSON, IPC paths | same, but names are de-duplicated everywhere — polars rejects duplicate columns outright |

`has_header=True` composes with `column_names` by still consuming the first record as a header, but letting `column_names` win over it.

## Duplicate names

`select 1 as a, 2 as a` is legal SQL, and the issue asks for at least one accessor to carry the caller's names verbatim. The names are applied *before* the existing duplicate-name de-duplication in each backend's `__init__`, so `ArrowBackend.source_data` keeps `["a", "a"]` while `.data` — what the widget renders — still gets `["a", "a0"]`. Nothing about the existing de-duplication changes.

`PolarsBackend` de-duplicates everywhere, since polars does not allow duplicate column names at all.

## Implementation

Two new module-level helpers in `backend.py` hold the rules:

- `_empty_table(names)` — a string-typed, zero-row table with those columns.
- `_relabel(data, names)` — no columns at all → build from names; one name per column → rename; any other count → return the data unchanged.

`_deduplicate()` is factored out of `ArrowBackend.__init__` and reused by `PolarsBackend.__init__`. `ArrowBackend.from_records` applies the names after the table is built rather than keying a pydict by them, so duplicates among them survive.

The widget layer is untouched — `DataTable` keeps using `column_labels`.

## Also in this PR

`tests/unit_tests/test_arrow_backend.py::test_from_parquet` was already failing on `main`: 0.16.1 made `pyarrow.parquet` a lazy import, so `pa.parquet` is no longer bound when the test reaches for it. Fixed with an explicit import in the test file. Happy to split this out if you'd rather it land separately.

## Testing

`test_create_backend.py` goes from 2 tests to 23, covering each row of the table above plus `max_rows` interaction, mismatched counts, and the duplicate-name guarantee on `source_data`.

`make check` is clean: 108 passed / 4 skipped (including the 18 snapshots, unchanged), `ruff format`, `ruff check`, and strict `mypy` all green. Also confirmed by hand that `backend.py` still imports without pulling in Textual or `pyarrow.parquet`.

README gains a "Supplying column names" section; `AGENTS.md` gains a note on where the rules live and why they run before de-duplication.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1SWWT6LjwTJgStmmtExrP)_