### PR TITLE
perf: import rich lazily in backend.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,9 @@ reporting the full input — the widget shows both counts.
 `column_content_widths` is the hot path for first paint. Each backend computes it with
 vectorized column operations rather than per-cell Python (`_measure`): booleans and nulls
 are constants, numerics measure only min/max, temporals measure one non-null value, and
-everything else casts the whole column to string and takes `max(utf8_length)`. The result
+everything else casts the whole column to string and takes `max(utf8_length)`. The
+per-value fallback is `backend._measure_width`, which owns the lazily built rich `Console`
+(see Conventions). The result
 is cached on the backend and cleared by `_reset_content_widths()` on mutation. The Arrow
 path registers a PyArrow scalar UDF as a fallback for types Arrow can't cast to string.
 
@@ -116,22 +118,26 @@ message on `ctrl+c`/`super+c` — this requires the host app to be built with
   over `ArrowBackend` and `PolarsBackend` — behavior changes should hold for both.
 - Snapshot tests (`tests/snapshot_tests/`) each mount a tiny app from `snapshot_apps/` and
   compare rendered SVGs. Review diffs before running `--snapshot-update`.
-- `backend.py`, `format.py`, and `column.py` must stay free of Textual imports, so that
-  downstream consumers (harlequin's headless `hsql` CLI) can use `create_backend()`
-  without paying for the framework. Two deliberate deferrals keep this true, and **neither
-  is covered by a test** — adding a convenience import to the top of `__init__.py` silently
-  undoes the first, and any module-scope `pq.` use undoes the second:
+- `backend.py` must stay importable without Textual or rich, so that downstream consumers
+  (harlequin's headless `hsql` CLI) can use `create_backend()` as a normalizer without
+  paying for display. `format.py` and `column.py` may use rich, but must stay free of
+  Textual. Three deliberate deferrals keep this true:
   - `__init__.py` imports `DataTable` lazily via a module-level `__getattr__` (PEP 562),
-    with a `TYPE_CHECKING` import so mypy still resolves it for downstream users.
+    with a `TYPE_CHECKING` import so mypy still resolves it for downstream users. A
+    convenience import at the top of `__init__.py` silently undoes this.
   - `pyarrow.parquet` is imported inside `ArrowBackend.from_parquet`, its only use site.
     `pyarrow.compute`/`types`/`lib` stay at module scope; they're used in the hot path.
+    Any module-scope `pq.` use undoes this.
+  - `backend._measure_width` imports rich and `format.measure_width` on first call, and
+    builds its module-level `Console` there. Backends must not import either at module
+    scope, or construct a `Console` in `__init__`.
 
-  Check by hand after touching either file — both print `False`, and the import costs 186
-  modules on 3.10 against the required deps (523 with the `polars` extra, which `uv sync`
-  installs):
+  `tests/unit_tests/test_lazy_imports.py` asserts all three, in a subprocess. To check by
+  hand (all `False`; the import costs ~225 modules on 3.10 against the required deps, 450
+  with the `polars` extra, which `uv sync` installs):
 
   ```bash
-  uv run python -c "import sys; from textual_fastdatatable.backend import create_backend; print('textual' in sys.modules, 'pyarrow.parquet' in sys.modules, len(sys.modules))"
+  uv run python -c "import sys; from textual_fastdatatable.backend import create_backend; print('textual' in sys.modules, 'rich' in sys.modules, 'pyarrow.parquet' in sys.modules, len(sys.modules))"
   ```
 - `tests/unit_tests/test_wheels.py` resolves the dependency floors in `pyproject.toml` for
   every supported Python/platform with wheels only. It shells out to `uv` and hits PyPI, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- `textual_fastdatatable.backend` can now be imported without importing `rich`: the
-  `Console` used to measure column widths is now built on first measurement, and `rich`
-  and `textual_fastdatatable.format` are imported at that point instead of at module
-  scope. `create_backend()` no longer constructs a `Console` at all, so consumers that
-  never render (harlequin's headless `hsql` CLI) skip ~50 modules and ~30ms
+- `textual_fastdatatable.backend` can now be imported without importing `rich`, which is
+  now imported (with the `Console` it provides) on the first column-width measurement, so
+  consumers that never render skip ~50 modules and ~30ms
   ([#168](https://github.com/tconbeer/textual-fastdatatable/issues/168)).
-- The lazy imports in `backend.py` and `__init__.py` are now covered by tests.
 
 ## [0.17.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- `textual_fastdatatable.backend` can now be imported without importing `rich`: the
+  `Console` used to measure column widths is now built on first measurement, and `rich`
+  and `textual_fastdatatable.format` are imported at that point instead of at module
+  scope. `create_backend()` no longer constructs a `Console` at all, so consumers that
+  never render (harlequin's headless `hsql` CLI) skip ~50 modules and ~30ms
+  ([#168](https://github.com/tconbeer/textual-fastdatatable/issues/168)).
+- The lazy imports in `backend.py` and `__init__.py` are now covered by tests.
+
 ## [0.17.0] - 2026-08-09
 
 - `create_backend()` (and the backend constructors it dispatches to) now accept a

--- a/src/textual_fastdatatable/backend.py
+++ b/src/textual_fastdatatable/backend.py
@@ -6,15 +6,15 @@ from collections.abc import Iterable, Mapping, Sequence
 from contextlib import suppress
 from datetime import date, datetime
 from pathlib import Path
-from typing import Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 import pyarrow as pa
 import pyarrow.compute as pc
 import pyarrow.lib as pal
 import pyarrow.types as pt
-from rich.console import Console
 
-from textual_fastdatatable.format import measure_width
+if TYPE_CHECKING:
+    from rich.console import Console
 
 AutoBackendType = Any
 
@@ -25,6 +25,25 @@ except ImportError:
     _HAS_POLARS = False
 else:
     _HAS_POLARS = True
+
+_console: "Console | None" = None
+
+
+def _measure_width(value: Any) -> int:
+    """The rendered width of one value, for column_content_widths.
+
+    rich is imported (and the Console built) on first call, so that importing
+    this module costs nothing for consumers that never measure anything.
+    """
+    global _console
+
+    from textual_fastdatatable.format import measure_width
+
+    if _console is None:
+        from rich.console import Console
+
+        _console = Console()
+    return measure_width(value, _console)
 
 
 def create_backend(
@@ -309,7 +328,6 @@ class ArrowBackend(DataTableBackend[pa.Table]):
             self.data = data.slice(offset=0, length=max_rows)
         else:
             self.data = data
-        self._console = Console()
         self._column_content_widths: list[int] = []
 
     @staticmethod
@@ -492,7 +510,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
 
         self.data = self.data.append_column(label, arr)
         if self._column_content_widths:
-            self._column_content_widths.append(measure_width(default, self._console))
+            self._column_content_widths.append(_measure_width(default))
         return self.data.num_columns - 1
 
     def append_rows(self, records: Iterable[Iterable[Any]]) -> list[int]:
@@ -530,7 +548,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         )
         if self._column_content_widths:
             self._column_content_widths[column_index] = max(
-                measure_width(value, self._console),
+                _measure_width(value),
                 self._column_content_widths[column_index],
             )
 
@@ -566,7 +584,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
                 col_min = pc.min(arr.fill_null(0)).as_py()
             except OverflowError:
                 col_min = -9223372036854775807
-            return max([measure_width(el, self._console) for el in [col_max, col_min]])
+            return max([_measure_width(el) for el in [col_max, col_min]])
         elif pt.is_temporal(arr.type):
             try:
                 value = arr.drop_null()[0].as_py()
@@ -576,7 +594,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
                 return 24
             else:
                 # valid temporal types all have the same width for their type
-                return measure_width(value, self._console)
+                return _measure_width(value)
 
         # for everything else, we need to compute it
         # First, cast the data to strings
@@ -684,7 +702,6 @@ if _HAS_POLARS:
                 self.data = data.slice(offset=0, length=max_rows)
             else:
                 self.data = data
-            self._console = Console()
             self._column_content_widths: list[int] = []
 
         @property
@@ -763,9 +780,7 @@ if _HAS_POLARS:
                 .alias(label)
             )
             if self._column_content_widths:
-                self._column_content_widths.append(
-                    measure_width(default, self._console)
-                )
+                self._column_content_widths.append(_measure_width(default))
             return len(self.data.columns) - 1
 
         def _reset_content_widths(self) -> None:
@@ -786,7 +801,7 @@ if _HAS_POLARS:
             )
             if self._column_content_widths:
                 self._column_content_widths[column_index] = max(
-                    measure_width(value, self._console),
+                    _measure_width(value),
                     self._column_content_widths[column_index],
                 )
 
@@ -811,16 +826,14 @@ if _HAS_POLARS:
             if dtype.is_decimal() or dtype.is_float() or dtype.is_integer():
                 col_max = arr.max()
                 col_min = arr.min()
-                return max(
-                    [measure_width(el, self._console) for el in [col_max, col_min]]
-                )
+                return max([_measure_width(el) for el in [col_max, col_min]])
             if dtype.is_temporal():
                 try:
                     value = arr.drop_nulls()[0]
                 except IndexError:
                     return 0
                 else:
-                    return measure_width(value, self._console)
+                    return _measure_width(value)
             if dtype.is_(pld.Boolean()):
                 return 7
 

--- a/tests/unit_tests/test_lazy_imports.py
+++ b/tests/unit_tests/test_lazy_imports.py
@@ -1,0 +1,40 @@
+import subprocess
+import sys
+
+import pytest
+
+# importing the backend must not import these; each is deferred to its use site,
+# so that consumers that never render pay for none of them.
+DEFERRED = ["textual", "rich", "pyarrow.parquet"]
+
+
+def _imported_modules(script: str) -> set[str]:
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return set(proc.stdout.split())
+
+
+@pytest.mark.parametrize("module", DEFERRED)
+def test_backend_import_is_lazy(module: str) -> None:
+    modules = _imported_modules(
+        "import sys\n"
+        "from textual_fastdatatable.backend import create_backend\n"
+        "print('\\n'.join(sys.modules))\n"
+    )
+    assert module not in modules
+
+
+def test_measuring_widths_imports_rich() -> None:
+    """The deferred names still arrive when something actually needs them."""
+    modules = _imported_modules(
+        "import sys\n"
+        "from textual_fastdatatable.backend import create_backend\n"
+        "backend = create_backend([['a', 1], ['b', 2]])\n"
+        "assert backend.column_content_widths == [1, 1]\n"
+        "print('\\n'.join(sys.modules))\n"
+    )
+    assert "rich" in modules


### PR DESCRIPTION
Closes #168, taking shape (1): defer both imports, non-breaking.

## Changes

`backend.py`:
- Drops the module-scope `from rich.console import Console` and `from textual_fastdatatable.format import measure_width`; `Console` stays under `TYPE_CHECKING` for the annotation.
- Adds `_measure_width(value)`, which imports rich and `measure_width` on first call and builds a module-level `Console` there. All seven call sites — `_measure`, `append_column`, `update_cell` on both `ArrowBackend` and `PolarsBackend` — go through it.
- Removes `self._console = Console()` from both `__init__`s, so `create_backend()` no longer probes env vars and the terminal for consumers that never render.

The `Console` is now shared across backends rather than one per instance. It is constructed identically each time and `Console.width` re-detects per call, so measurement is unchanged.

No API changes. `column_content_widths` stays where it is, so this doesn't foreclose shape (2) or (3) from the issue.

## Tests

New `tests/unit_tests/test_lazy_imports.py` asserts, in a subprocess, that `textual`, `rich`, and `pyarrow.parquet` are all absent from `sys.modules` after `from textual_fastdatatable.backend import create_backend` — and that rich does arrive once `column_content_widths` is read. That also covers the two pre-existing deferrals AGENTS.md flagged as untested.

Local run: `ruff format --check`, `ruff check`, and `mypy --no-incremental` clean; 87 passed / 4 skipped (`test_wheels.py` deselected, it hits PyPI).

## Docs

CHANGELOG entry under Unreleased. AGENTS.md conventions now list three deferrals and point at the new test.

One number to flag: the previously documented import floor of 186 modules doesn't reproduce here — I measure ~225 on 3.10 without the `polars` extra, which matches the 223 measured in the issue for this patch, and 450 with the extra. I updated AGENTS.md to the measured values rather than keeping the old ones.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCXXe38GrdZYAXHQwT1dgH)_