### PR TITLE
Remove markup from content width calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
   content is now truncated (with a `… (truncated)` marker) to at most half the height of
   the screen, so the tooltip can no longer be clamped over the mouse, which caused
   Textual to clear and re-show it indefinitely.
+- The backend now measures column widths based on whether or not strings will be
+  rendered as Rich markup ([#171](https://github.com/tconbeer/textual-fastdatatable/pull/171)).
 
 ## [0.17.1] - 2026-08-10
 

--- a/src/textual_fastdatatable/backend.py
+++ b/src/textual_fastdatatable/backend.py
@@ -51,6 +51,7 @@ def create_backend(
     max_rows: int | None = None,
     has_header: bool = False,
     column_names: Sequence[str] | None = None,
+    render_markup: bool = True,
 ) -> DataTableBackend:
     """Create a backend for `data`, picking the implementation from its type.
 
@@ -78,12 +79,12 @@ def create_backend(
         When `column_names` is not passed, every case behaves as it always has.
     """
     if data is None and column_names is not None:
-        return ArrowBackend(_empty_table(column_names), max_rows=max_rows)
+        return ArrowBackend(_empty_table(column_names), max_rows=max_rows, render_markup=render_markup)
     if isinstance(data, pa.Table):
-        return ArrowBackend(data, max_rows=max_rows, column_names=column_names)
+        return ArrowBackend(data, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
     if isinstance(data, pa.RecordBatch):
         return ArrowBackend.from_batches(
-            data, max_rows=max_rows, column_names=column_names
+            data, max_rows=max_rows, column_names=column_names, render_markup=render_markup
         )
     if _HAS_POLARS and isinstance(data, pl.DataFrame):
         return PolarsBackend.from_dataframe(
@@ -91,14 +92,14 @@ def create_backend(
         )
     if _is_pandas_dataframe(data):
         return ArrowBackend.from_pandas(
-            data, max_rows=max_rows, column_names=column_names
+            data, max_rows=max_rows, column_names=column_names, render_markup=render_markup
         )
 
     if isinstance(data, Path) or isinstance(data, str):
         data = Path(data)
         if data.suffix in [".pqt", ".parquet"]:
             return ArrowBackend.from_parquet(
-                data, max_rows=max_rows, column_names=column_names
+                data, max_rows=max_rows, column_names=column_names, render_markup=render_markup
             )
         if _HAS_POLARS:
             return PolarsBackend.from_file_path(
@@ -108,10 +109,10 @@ def create_backend(
                 column_names=column_names,
             )
     if isinstance(data, Sequence) and not data:
-        return ArrowBackend(pa.table([]), max_rows=max_rows, column_names=column_names)
+        return ArrowBackend(pa.table([]), max_rows=max_rows, column_names=column_names, render_markup=render_markup)
     if isinstance(data, Sequence) and _is_iterable(data[0]):
         return ArrowBackend.from_records(
-            data, max_rows=max_rows, has_header=has_header, column_names=column_names
+            data, max_rows=max_rows, has_header=has_header, column_names=column_names, render_markup=render_markup
         )
 
     if (
@@ -120,7 +121,7 @@ def create_backend(
         and isinstance(next(iter(data.values())), Sequence)
     ):
         return ArrowBackend.from_pydict(
-            data, max_rows=max_rows, column_names=column_names
+            data, max_rows=max_rows, column_names=column_names, render_markup=render_markup
         )
 
     raise TypeError(
@@ -200,6 +201,7 @@ class DataTableBackend(ABC, Generic[_TableTypeT]):
         data: _TableTypeT,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
+        render_markup: bool = True,
     ) -> None:
         pass
 
@@ -210,6 +212,7 @@ class DataTableBackend(ABC, Generic[_TableTypeT]):
         data: Mapping[str, Sequence[Any]],
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
+        render_markup: bool = True,
     ) -> "DataTableBackend":
         pass
 
@@ -310,6 +313,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         data: pa.Table,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
+        render_markup: bool = True,
     ) -> None:
         # the caller's names are applied first, so that source_data carries them
         # verbatim, duplicates and all.
@@ -329,6 +333,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         else:
             self.data = data
         self._column_content_widths: list[int] = []
+        self.render_markup = render_markup
 
     @staticmethod
     def _pydict_from_records(
@@ -375,9 +380,10 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         data: pa.RecordBatch,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
+        render_markup: bool = True,
     ) -> "ArrowBackend":
         tbl = pa.Table.from_batches([data])
-        return cls(tbl, max_rows=max_rows, column_names=column_names)
+        return cls(tbl, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
 
     @classmethod
     def from_parquet(
@@ -385,13 +391,14 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         path: Path | str,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
+        render_markup: bool = True,
     ) -> "ArrowBackend":
         # deferred: parquet is the only pyarrow submodule not used elsewhere in
         # this module, and it is expensive to import.
         import pyarrow.parquet as pq
 
         tbl = pq.read_table(str(path))
-        return cls(tbl, max_rows=max_rows, column_names=column_names)
+        return cls(tbl, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
 
     @classmethod
     def from_pandas(
@@ -399,6 +406,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         frame: Any,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
+        render_markup: bool = True,
     ) -> "ArrowBackend":
         """Create a backend from a pandas DataFrame.
 
@@ -406,7 +414,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         show it as a column.
         """
         tbl = pa.Table.from_pandas(frame, preserve_index=False)
-        return cls(tbl, max_rows=max_rows, column_names=column_names)
+        return cls(tbl, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
 
     @classmethod
     def from_pydict(
@@ -414,6 +422,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         data: Mapping[str, Sequence[Any]],
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
+        render_markup: bool = True,
     ) -> "ArrowBackend":
         try:
             tbl = pa.Table.from_pydict(dict(data))
@@ -425,7 +434,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
                 for k, v in data.items()
             }
             tbl = pa.Table.from_pydict(new_data)
-        return cls(tbl, max_rows=max_rows, column_names=column_names)
+        return cls(tbl, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
 
     @classmethod
     def from_records(
@@ -434,11 +443,12 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         has_header: bool = False,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
+        render_markup: bool = True,
     ) -> "ArrowBackend":
         # column_names are applied by __init__, after the table is built: a
         # pydict keyed by them would drop any duplicates among them.
         pydict = cls._pydict_from_records(records, has_header)
-        return cls.from_pydict(pydict, max_rows=max_rows, column_names=column_names)
+        return cls.from_pydict(pydict, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
 
     @property
     def source_data(self) -> pa.Table:
@@ -623,7 +633,8 @@ class ArrowBackend(DataTableBackend[pa.Table]):
             arr = pc.call_function(udf_name, [arr])
 
         # remove rich markup text from width calculation
-        arr = pc.replace_substring_regex(arr, pattern=r'\[/?[a-zA-Z0-9 _.#=,]*\]', replacement='')
+        if self.render_markup:
+            arr = pc.replace_substring_regex(arr, pattern=r'\[/?[a-zA-Z0-9 _.#=,]*\]', replacement='')
 
         # next, try to measure the UTF-encoded string length of each cell,
         # then take the max

--- a/src/textual_fastdatatable/backend.py
+++ b/src/textual_fastdatatable/backend.py
@@ -28,6 +28,14 @@ else:
 
 _console: "Console | None" = None
 
+_RENDER_MARKUP_DEFAULT = False
+"""
+This is false only when there is no DataTable front-end is attached...
+as soon as the front-end is attached, the backend will take its value,
+unless column widths have already been computed, in which case the backend
+will raise an error.
+"""
+
 _RICH_MARKUP_TAG_PATTERN = r"\[{2,}[^\]]*\]{2,}|(\[\/?[a-zA-Z0-9_\s#=.:/\-\(\)]+?\])"
 """
 Matches tags like [yellow on black] but not escaped double brackets like [[]]
@@ -56,7 +64,6 @@ def create_backend(
     max_rows: int | None = None,
     has_header: bool = False,
     column_names: Sequence[str] | None = None,
-    render_markup: bool = True,
 ) -> DataTableBackend:
     """Create a backend for `data`, picking the implementation from its type.
 
@@ -84,22 +91,12 @@ def create_backend(
         When `column_names` is not passed, every case behaves as it always has.
     """
     if data is None and column_names is not None:
-        return ArrowBackend(
-            _empty_table(column_names), max_rows=max_rows, render_markup=render_markup
-        )
+        return ArrowBackend(_empty_table(column_names), max_rows=max_rows)
     if isinstance(data, pa.Table):
-        return ArrowBackend(
-            data,
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
-        )
+        return ArrowBackend(data, max_rows=max_rows, column_names=column_names)
     if isinstance(data, pa.RecordBatch):
         return ArrowBackend.from_batches(
-            data,
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
+            data, max_rows=max_rows, column_names=column_names
         )
     if _HAS_POLARS and isinstance(data, pl.DataFrame):
         return PolarsBackend.from_dataframe(
@@ -107,20 +104,14 @@ def create_backend(
         )
     if _is_pandas_dataframe(data):
         return ArrowBackend.from_pandas(
-            data,
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
+            data, max_rows=max_rows, column_names=column_names
         )
 
     if isinstance(data, Path) or isinstance(data, str):
         data = Path(data)
         if data.suffix in [".pqt", ".parquet"]:
             return ArrowBackend.from_parquet(
-                data,
-                max_rows=max_rows,
-                column_names=column_names,
-                render_markup=render_markup,
+                data, max_rows=max_rows, column_names=column_names
             )
         if _HAS_POLARS:
             return PolarsBackend.from_file_path(
@@ -130,19 +121,10 @@ def create_backend(
                 column_names=column_names,
             )
     if isinstance(data, Sequence) and not data:
-        return ArrowBackend(
-            pa.table([]),
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
-        )
+        return ArrowBackend(pa.table([]), max_rows=max_rows, column_names=column_names)
     if isinstance(data, Sequence) and _is_iterable(data[0]):
         return ArrowBackend.from_records(
-            data,
-            max_rows=max_rows,
-            has_header=has_header,
-            column_names=column_names,
-            render_markup=render_markup,
+            data, max_rows=max_rows, has_header=has_header, column_names=column_names
         )
 
     if (
@@ -151,10 +133,7 @@ def create_backend(
         and isinstance(next(iter(data.values())), Sequence)
     ):
         return ArrowBackend.from_pydict(
-            data,
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
+            data, max_rows=max_rows, column_names=column_names
         )
 
     raise TypeError(
@@ -234,9 +213,8 @@ class DataTableBackend(ABC, Generic[_TableTypeT]):
         data: _TableTypeT,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
-        render_markup: bool = True,
     ) -> None:
-        pass
+        self._render_markup: bool | None = None
 
     @classmethod
     @abstractmethod
@@ -245,7 +223,6 @@ class DataTableBackend(ABC, Generic[_TableTypeT]):
         data: Mapping[str, Sequence[Any]],
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
-        render_markup: bool = True,
     ) -> "DataTableBackend":
         pass
 
@@ -284,6 +261,30 @@ class DataTableBackend(ABC, Generic[_TableTypeT]):
         A list of column labels
         """
         pass
+
+    @property
+    def render_markup(self) -> bool:
+        """
+        If true, column content widths reflect the rendered width. If
+        accessed before being set, automatically sets to the default
+        value.
+        """
+        if self._render_markup is None:
+            self._render_markup = _RENDER_MARKUP_DEFAULT
+        return self._render_markup
+
+    @render_markup.setter
+    def render_markup(self, new_value: bool) -> None:
+        """
+        Set the render_markup property, but do NOT allow this to be changed
+        after it is set the first time.
+        """
+        if self._render_markup is not None and self._render_markup != new_value:
+            raise ValueError(
+                "Cannot change render_markup once set or accessed. "
+                f"Already set to {self._render_markup}"
+            )
+        self._render_markup = new_value
 
     @property
     @abstractmethod
@@ -346,7 +347,6 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         data: pa.Table,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
-        render_markup: bool = True,
     ) -> None:
         # the caller's names are applied first, so that source_data carries them
         # verbatim, duplicates and all.
@@ -366,7 +366,8 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         else:
             self.data = data
         self._column_content_widths: list[int] = []
-        self.render_markup = render_markup
+        # default _render_markup to an "unset" value
+        self._render_markup = None
 
     @staticmethod
     def _pydict_from_records(
@@ -413,15 +414,9 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         data: pa.RecordBatch,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
-        render_markup: bool = True,
     ) -> "ArrowBackend":
         tbl = pa.Table.from_batches([data])
-        return cls(
-            tbl,
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
-        )
+        return cls(tbl, max_rows=max_rows, column_names=column_names)
 
     @classmethod
     def from_parquet(
@@ -429,19 +424,13 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         path: Path | str,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
-        render_markup: bool = True,
     ) -> "ArrowBackend":
         # deferred: parquet is the only pyarrow submodule not used elsewhere in
         # this module, and it is expensive to import.
         import pyarrow.parquet as pq
 
         tbl = pq.read_table(str(path))
-        return cls(
-            tbl,
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
-        )
+        return cls(tbl, max_rows=max_rows, column_names=column_names)
 
     @classmethod
     def from_pandas(
@@ -449,7 +438,6 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         frame: Any,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
-        render_markup: bool = True,
     ) -> "ArrowBackend":
         """Create a backend from a pandas DataFrame.
 
@@ -457,12 +445,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         show it as a column.
         """
         tbl = pa.Table.from_pandas(frame, preserve_index=False)
-        return cls(
-            tbl,
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
-        )
+        return cls(tbl, max_rows=max_rows, column_names=column_names)
 
     @classmethod
     def from_pydict(
@@ -470,7 +453,6 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         data: Mapping[str, Sequence[Any]],
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
-        render_markup: bool = True,
     ) -> "ArrowBackend":
         try:
             tbl = pa.Table.from_pydict(dict(data))
@@ -482,12 +464,7 @@ class ArrowBackend(DataTableBackend[pa.Table]):
                 for k, v in data.items()
             }
             tbl = pa.Table.from_pydict(new_data)
-        return cls(
-            tbl,
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
-        )
+        return cls(tbl, max_rows=max_rows, column_names=column_names)
 
     @classmethod
     def from_records(
@@ -496,17 +473,11 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         has_header: bool = False,
         max_rows: int | None = None,
         column_names: Sequence[str] | None = None,
-        render_markup: bool = True,
     ) -> "ArrowBackend":
         # column_names are applied by __init__, after the table is built: a
         # pydict keyed by them would drop any duplicates among them.
         pydict = cls._pydict_from_records(records, has_header)
-        return cls.from_pydict(
-            pydict,
-            max_rows=max_rows,
-            column_names=column_names,
-            render_markup=render_markup,
-        )
+        return cls.from_pydict(pydict, max_rows=max_rows, column_names=column_names)
 
     @property
     def source_data(self) -> pa.Table:
@@ -736,13 +707,9 @@ if _HAS_POLARS:
             pydict: Mapping[str, Sequence[Any]],
             max_rows: int | None = None,
             column_names: Sequence[str] | None = None,
-            render_markup: bool = True,
         ) -> "PolarsBackend":
             return cls(
-                pl.from_dict(pydict),
-                max_rows=max_rows,
-                column_names=column_names,
-                render_markup=render_markup,
+                pl.from_dict(pydict), max_rows=max_rows, column_names=column_names
             )
 
         @classmethod
@@ -759,7 +726,6 @@ if _HAS_POLARS:
             data: pl.DataFrame,
             max_rows: int | None = None,
             column_names: Sequence[str] | None = None,
-            render_markup: bool = True,
         ) -> None:
             self._source_data = data
 
@@ -782,7 +748,7 @@ if _HAS_POLARS:
             else:
                 self.data = data
             self._column_content_widths: list[int] = []
-            self.render_markup = render_markup
+            self._render_markup = None
 
         @property
         def source_data(self) -> pl.DataFrame:

--- a/src/textual_fastdatatable/backend.py
+++ b/src/textual_fastdatatable/backend.py
@@ -622,6 +622,9 @@ class ArrowBackend(DataTableBackend[pa.Table]):
 
             arr = pc.call_function(udf_name, [arr])
 
+        # remove rich markup text from width calculation
+        arr = pc.replace_substring_regex(arr, pattern=r'\[/?[a-zA-Z0-9 _.#=,]*\]', replacement='')
+
         # next, try to measure the UTF-encoded string length of each cell,
         # then take the max
         try:

--- a/src/textual_fastdatatable/backend.py
+++ b/src/textual_fastdatatable/backend.py
@@ -28,6 +28,11 @@ else:
 
 _console: "Console | None" = None
 
+_RICH_MARKUP_TAG_PATTERN = r"\[{2,}[^\]]*\]{2,}|(\[\/?[a-zA-Z0-9_\s#=.:/\-\(\)]+?\])"
+"""
+Matches tags like [yellow on black] but not escaped double brackets like [[]]
+"""
+
 
 def _measure_width(value: Any) -> int:
     """The rendered width of one value, for column_content_widths.
@@ -79,12 +84,22 @@ def create_backend(
         When `column_names` is not passed, every case behaves as it always has.
     """
     if data is None and column_names is not None:
-        return ArrowBackend(_empty_table(column_names), max_rows=max_rows, render_markup=render_markup)
+        return ArrowBackend(
+            _empty_table(column_names), max_rows=max_rows, render_markup=render_markup
+        )
     if isinstance(data, pa.Table):
-        return ArrowBackend(data, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
+        return ArrowBackend(
+            data,
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
+        )
     if isinstance(data, pa.RecordBatch):
         return ArrowBackend.from_batches(
-            data, max_rows=max_rows, column_names=column_names, render_markup=render_markup
+            data,
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
         )
     if _HAS_POLARS and isinstance(data, pl.DataFrame):
         return PolarsBackend.from_dataframe(
@@ -92,14 +107,20 @@ def create_backend(
         )
     if _is_pandas_dataframe(data):
         return ArrowBackend.from_pandas(
-            data, max_rows=max_rows, column_names=column_names, render_markup=render_markup
+            data,
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
         )
 
     if isinstance(data, Path) or isinstance(data, str):
         data = Path(data)
         if data.suffix in [".pqt", ".parquet"]:
             return ArrowBackend.from_parquet(
-                data, max_rows=max_rows, column_names=column_names, render_markup=render_markup
+                data,
+                max_rows=max_rows,
+                column_names=column_names,
+                render_markup=render_markup,
             )
         if _HAS_POLARS:
             return PolarsBackend.from_file_path(
@@ -109,10 +130,19 @@ def create_backend(
                 column_names=column_names,
             )
     if isinstance(data, Sequence) and not data:
-        return ArrowBackend(pa.table([]), max_rows=max_rows, column_names=column_names, render_markup=render_markup)
+        return ArrowBackend(
+            pa.table([]),
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
+        )
     if isinstance(data, Sequence) and _is_iterable(data[0]):
         return ArrowBackend.from_records(
-            data, max_rows=max_rows, has_header=has_header, column_names=column_names, render_markup=render_markup
+            data,
+            max_rows=max_rows,
+            has_header=has_header,
+            column_names=column_names,
+            render_markup=render_markup,
         )
 
     if (
@@ -121,7 +151,10 @@ def create_backend(
         and isinstance(next(iter(data.values())), Sequence)
     ):
         return ArrowBackend.from_pydict(
-            data, max_rows=max_rows, column_names=column_names, render_markup=render_markup
+            data,
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
         )
 
     raise TypeError(
@@ -383,7 +416,12 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         render_markup: bool = True,
     ) -> "ArrowBackend":
         tbl = pa.Table.from_batches([data])
-        return cls(tbl, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
+        return cls(
+            tbl,
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
+        )
 
     @classmethod
     def from_parquet(
@@ -398,7 +436,12 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         import pyarrow.parquet as pq
 
         tbl = pq.read_table(str(path))
-        return cls(tbl, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
+        return cls(
+            tbl,
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
+        )
 
     @classmethod
     def from_pandas(
@@ -414,7 +457,12 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         show it as a column.
         """
         tbl = pa.Table.from_pandas(frame, preserve_index=False)
-        return cls(tbl, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
+        return cls(
+            tbl,
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
+        )
 
     @classmethod
     def from_pydict(
@@ -434,7 +482,12 @@ class ArrowBackend(DataTableBackend[pa.Table]):
                 for k, v in data.items()
             }
             tbl = pa.Table.from_pydict(new_data)
-        return cls(tbl, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
+        return cls(
+            tbl,
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
+        )
 
     @classmethod
     def from_records(
@@ -448,7 +501,12 @@ class ArrowBackend(DataTableBackend[pa.Table]):
         # column_names are applied by __init__, after the table is built: a
         # pydict keyed by them would drop any duplicates among them.
         pydict = cls._pydict_from_records(records, has_header)
-        return cls.from_pydict(pydict, max_rows=max_rows, column_names=column_names, render_markup=render_markup)
+        return cls.from_pydict(
+            pydict,
+            max_rows=max_rows,
+            column_names=column_names,
+            render_markup=render_markup,
+        )
 
     @property
     def source_data(self) -> pa.Table:
@@ -634,7 +692,9 @@ class ArrowBackend(DataTableBackend[pa.Table]):
 
         # remove rich markup text from width calculation
         if self.render_markup:
-            arr = pc.replace_substring_regex(arr, pattern=r'\[/?[a-zA-Z0-9 _.#=,]*\]', replacement='')
+            arr = pc.replace_substring_regex(
+                arr, pattern=_RICH_MARKUP_TAG_PATTERN, replacement=""
+            )
 
         # next, try to measure the UTF-encoded string length of each cell,
         # then take the max
@@ -676,9 +736,13 @@ if _HAS_POLARS:
             pydict: Mapping[str, Sequence[Any]],
             max_rows: int | None = None,
             column_names: Sequence[str] | None = None,
+            render_markup: bool = True,
         ) -> "PolarsBackend":
             return cls(
-                pl.from_dict(pydict), max_rows=max_rows, column_names=column_names
+                pl.from_dict(pydict),
+                max_rows=max_rows,
+                column_names=column_names,
+                render_markup=render_markup,
             )
 
         @classmethod
@@ -695,6 +759,7 @@ if _HAS_POLARS:
             data: pl.DataFrame,
             max_rows: int | None = None,
             column_names: Sequence[str] | None = None,
+            render_markup: bool = True,
         ) -> None:
             self._source_data = data
 
@@ -717,6 +782,7 @@ if _HAS_POLARS:
             else:
                 self.data = data
             self._column_content_widths: list[int] = []
+            self.render_markup = render_markup
 
         @property
         def source_data(self) -> pl.DataFrame:
@@ -857,6 +923,10 @@ if _HAS_POLARS:
                 pl.Utf8(),
                 strict=False,
             )
+
+            # remove rich markup text from width calculation
+            if self.render_markup:
+                arr = arr.str.replace_all(_RICH_MARKUP_TAG_PATTERN, "")
             width = arr.fill_null("<null>").str.len_chars().max()
             assert isinstance(width, int)
             return width

--- a/src/textual_fastdatatable/data_table.py
+++ b/src/textual_fastdatatable/data_table.py
@@ -575,6 +575,7 @@ class DataTable(ScrollView, can_focus=True):
                     data,
                     max_rows=max_rows,
                     has_header=(column_labels is None),
+                    render_markup=render_markup
                 )
             )
         except (TypeError, OSError) as e:

--- a/src/textual_fastdatatable/data_table.py
+++ b/src/textual_fastdatatable/data_table.py
@@ -575,7 +575,7 @@ class DataTable(ScrollView, can_focus=True):
                     data,
                     max_rows=max_rows,
                     has_header=(column_labels is None),
-                    render_markup=render_markup
+                    render_markup=render_markup,
                 )
             )
         except (TypeError, OSError) as e:

--- a/src/textual_fastdatatable/data_table.py
+++ b/src/textual_fastdatatable/data_table.py
@@ -572,16 +572,16 @@ class DataTable(ScrollView, can_focus=True):
                 backend
                 if backend is not None
                 else create_backend(
-                    data,
-                    max_rows=max_rows,
-                    has_header=(column_labels is None),
-                    render_markup=render_markup,
+                    data, max_rows=max_rows, has_header=(column_labels is None)
                 )
             )
         except (TypeError, OSError) as e:
             self.backend = None
             if data is not None:
                 self.post_message(self.DataLoadError(e))
+
+        if self.backend is not None:
+            self.backend.render_markup = render_markup
 
         self._column_labels: list[str | Text] | None = (
             list(column_labels) if column_labels is not None else None

--- a/stubs/pyarrow/compute.pyi
+++ b/stubs/pyarrow/compute.pyi
@@ -7,6 +7,7 @@ from . import DataType, MemoryPool, Scalar, _PandasConvertible
 
 class Expression: ...
 class ScalarAggregateOptions: ...
+class ReplaceSubstringOptions: ...
 
 class CastOptions:
     def __init__(
@@ -60,5 +61,15 @@ def assume_timezone(
     ambiguous: Literal["raise", "earliest", "latest"] = "raise",
     nonexistent: Literal["raise", "earliest", "latest"] = "raise",
     options: Any | None = None,
+    memory_pool: MemoryPool | None = None,
+) -> _PandasConvertible: ...
+def replace_substring_regex(
+    strings: _PandasConvertible,
+    /,
+    pattern: str,
+    replacement: str,
+    *,
+    max_replacements: int | None = None,
+    options: ReplaceSubstringOptions | None = None,
     memory_pool: MemoryPool | None = None,
 ) -> _PandasConvertible: ...


### PR DESCRIPTION
Removes any rich markup that may be in the content of a column during the width calculation.